### PR TITLE
Add support for struct generics to translator.

### DIFF
--- a/internal/coq/coq.go
+++ b/internal/coq/coq.go
@@ -112,9 +112,10 @@ func (d FieldDecl) Coq(needs_paren bool) string {
 
 // StructDecl is a Coq record for a Go struct
 type StructDecl struct {
-	Name    string
-	Fields  []FieldDecl
-	Comment string
+	Name           string
+	Fields         []FieldDecl
+	TypeParameters []TypeIdent
+	Comment        string
 }
 
 // CoqDecl implements the Decl interface
@@ -125,7 +126,16 @@ type StructDecl struct {
 func (d StructDecl) CoqDecl() string {
 	var pp buffer
 	pp.AddComment(d.Comment)
-	pp.Add("Definition %s := struct.decl [", d.Name)
+	// For generic structs, add type params and return type (return type is the same
+	// but can't be inferred with params).
+	var builder strings.Builder
+	if d.TypeParameters != nil {
+		for _, tp := range d.TypeParameters {
+			fmt.Fprintf(&builder, "(%s: ty) ", tp)
+		}
+		fmt.Fprintf(&builder, ": struct.descriptor ")
+	}
+	pp.Add("Definition %s %s:= struct.decl [", d.Name, builder.String())
 	pp.Indent(2)
 	for i, fd := range d.Fields {
 		sep := ";"

--- a/internal/examples/unittest/struct_generic.go
+++ b/internal/examples/unittest/struct_generic.go
@@ -1,0 +1,35 @@
+package unittest
+
+type KVPair[K any, V any] struct {
+	Key   K
+	Value V
+	Other NonGenericKVPair
+}
+
+type IndexedKVPair[K any, V any] struct {
+	Key   K
+	Value V
+	Index uint64
+}
+
+type NonGenericKVPair struct {
+	Key   uint64
+	Value string
+}
+
+func testGenericStructs() uint64 {
+	kv_pair_generic := KVPair[uint64, string]{}
+	kv_pair_generic_ptr := KVPair[uint64, *uint64]{}
+	kv_pair_partly_generic := IndexedKVPair[uint64, string]{}
+	kv_pair_non_generic := NonGenericKVPair{}
+	kv_pair_inner_generic := new(KVPair[uint64, KVPair[uint64, string]])
+	kv_pair_inner_non_generic := KVPair[uint64, NonGenericKVPair]{}
+	kv_pair_generic.Key = 1
+	kv_pair_partly_generic.Value = "generic_val"
+	kv_pair_non_generic.Key = 2
+	kv_pair_inner_generic.Key = 3
+	kv_pair_inner_generic.Value = kv_pair_generic
+	kv_pair_inner_non_generic.Key = 4
+	kv_pair_generic_ptr.Key = 0
+	return kv_pair_inner_generic.Value.Key
+}

--- a/internal/examples/unittest/unittest.gold.v
+++ b/internal/examples/unittest/unittest.gold.v
@@ -946,6 +946,47 @@ Definition stringLength: val :=
   rec: "stringLength" "s" :=
     StringLength "s".
 
+(* struct_generic.go *)
+
+Definition NonGenericKVPair := struct.decl [
+  "Key" :: uint64T;
+  "Value" :: stringT
+].
+
+Definition KVPair (K: ty) (V: ty) : struct.descriptor := struct.decl [
+  "Key" :: K;
+  "Value" :: V;
+  "Other" :: struct.t NonGenericKVPair
+].
+
+Definition IndexedKVPair (K: ty) (V: ty) : struct.descriptor := struct.decl [
+  "Key" :: K;
+  "Value" :: V;
+  "Index" :: uint64T
+].
+
+Definition testGenericStructs: val :=
+  rec: "testGenericStructs" <> :=
+    let: "kv_pair_generic" := struct.mk (KVPair uint64 string) [
+    ] in
+    let: "kv_pair_generic_ptr" := struct.mk (KVPair uint64 ptrT) [
+    ] in
+    let: "kv_pair_partly_generic" := struct.mk (IndexedKVPair uint64 string) [
+    ] in
+    let: "kv_pair_non_generic" := struct.mk NonGenericKVPair [
+    ] in
+    let: "kv_pair_inner_generic" := struct.alloc (KVPair uint64 (KVPair uint64 string)) (zero_val (struct.t (KVPair uint64 (KVPair uint64 string)))) in
+    let: "kv_pair_inner_non_generic" := struct.mk (KVPair uint64 NonGenericKVPair) [
+    ] in
+    struct.storeF (KVPair uint64 string) "Key" "kv_pair_generic" #1;;
+    struct.storeF (IndexedKVPair uint64 string) "Value" "kv_pair_partly_generic" #(str"generic_val");;
+    struct.storeF NonGenericKVPair "Key" "kv_pair_non_generic" #2;;
+    struct.storeF (KVPair uint64 (KVPair uint64 string)) "Key" "kv_pair_inner_generic" #3;;
+    struct.storeF (KVPair uint64 (KVPair uint64 string)) "Value" "kv_pair_inner_generic" "kv_pair_generic";;
+    struct.storeF (KVPair uint64 NonGenericKVPair) "Key" "kv_pair_inner_non_generic" #4;;
+    struct.storeF (KVPair uint64 ptrT) "Key" "kv_pair_generic_ptr" #0;;
+    struct.get (KVPair uint64 string) "Key" (struct.loadF (KVPair uint64 (KVPair uint64 string)) "Value" "kv_pair_inner_generic").
+
 (* struct_method.go *)
 
 Definition Point := struct.decl [

--- a/testdata/negative-tests/badgenerics2.go
+++ b/testdata/negative-tests/badgenerics2.go
@@ -1,5 +1,0 @@
-package example
-
-type Box[T any] struct { // ERROR generic named type
-	v T
-}

--- a/types.go
+++ b/types.go
@@ -199,6 +199,10 @@ func (ctx Ctx) coqType(e ast.Expr) coq.Type {
 		return ctx.coqFuncType(e)
 	case *ast.IndexExpr:
 		ctx.todo(e, "unsupported generic type instantiation")
+	case *ast.IndexListExpr:
+		// Type parameter list for generic struct
+		return ctx.coqTypeOfType(e, ctx.typeOf(e))
+
 	default:
 		ctx.unsupported(e, "unexpected type expr")
 	}
@@ -355,7 +359,9 @@ func (ctx Ctx) getStructInfo(t types.Type) (structTypeInfo, bool) {
 		t = pt.Elem()
 	}
 	if t, ok := t.(*types.Named); ok {
-		name := ctx.qualifiedName(t.Obj())
+		// For a generic struct, we have to call the descriptor function with type params,
+		// otherwise, this will just return the struct name.
+		name := getStructDescriptorFunction(ctx, t)
 		if structType, ok := t.Underlying().(*types.Struct); ok {
 			return structTypeInfo{
 				name:           name,


### PR DESCRIPTION
I did this by translating struct descriptors for structs with type parameters to be a function that takes the go types and returns a descriptor with the types resolved. This required replacing where we store the name of the struct with a call to
this function. This should not change how non-generic structs are translated.