### PR TITLE
Add support for struct generics to translator.

### DIFF
--- a/internal/coq/coq.go
+++ b/internal/coq/coq.go
@@ -112,9 +112,10 @@ func (d FieldDecl) Coq(needs_paren bool) string {
 
 // StructDecl is a Coq record for a Go struct
 type StructDecl struct {
-	Name    string
-	Fields  []FieldDecl
-	Comment string
+	Name           string
+	Fields         []FieldDecl
+	TypeParameters []TypeIdent
+	Comment        string
 }
 
 // CoqDecl implements the Decl interface
@@ -125,7 +126,16 @@ type StructDecl struct {
 func (d StructDecl) CoqDecl() string {
 	var pp buffer
 	pp.AddComment(d.Comment)
-	pp.Add("Definition %s := struct.decl [", d.Name)
+	// For generic structs, add type params and return type (return type is the same
+	// but can't be inferred with params).
+	var builder strings.Builder
+	if d.TypeParameters != nil {
+		for _, tp := range d.TypeParameters {
+			fmt.Fprintf(&builder, "(%s: ty) ", tp)
+		}
+		fmt.Fprintf(&builder, ": struct.descriptor ")
+	}
+	pp.Add("Definition %s %s:= struct.decl [", d.Name, builder.String())
 	pp.Indent(2)
 	for i, fd := range d.Fields {
 		sep := ";"

--- a/internal/coq/coq.go
+++ b/internal/coq/coq.go
@@ -314,10 +314,10 @@ func (t TypeIdent) Coq(needs_paren bool) string {
 	return string(t)
 }
 
-// Stores type params only for generic structs.
+// StructType represents a named struct.
 type StructType struct {
-	Name   string
-	Params []Type
+	Name       string
+	TypeParams []Type
 }
 
 func (t StructType) Coq(needs_paren bool) string {
@@ -484,10 +484,10 @@ type StructFieldAccessExpr struct {
 // params.
 func StructDesc(struc StructType) Expr {
 	var builder strings.Builder
-	if len(struc.Params) == 0 {
+	if len(struc.TypeParams) == 0 {
 		return GallinaIdent(struc.Name)
 	}
-	for _, p := range struc.Params {
+	for _, p := range struc.TypeParams {
 		fmt.Fprintf(&builder, " %s", p.Coq(true))
 	}
 	return GallinaIdent(fmt.Sprintf("(%s%s)", struc.Name, builder.String()))

--- a/internal/examples/unittest/struct_generic.go
+++ b/internal/examples/unittest/struct_generic.go
@@ -1,0 +1,35 @@
+package unittest
+
+type KVPair[K any, V any] struct {
+	Key   K
+	Value V
+	Other NonGenericKVPair
+}
+
+type IndexedKVPair[K any, V any] struct {
+	Key   K
+	Value V
+	Index uint64
+}
+
+type NonGenericKVPair struct {
+	Key   uint64
+	Value string
+}
+
+func testGenericStructs() uint64 {
+	kv_pair_generic := KVPair[uint64, string]{}
+	kv_pair_generic_ptr := KVPair[uint64, *uint64]{}
+	kv_pair_partly_generic := IndexedKVPair[uint64, string]{}
+	kv_pair_non_generic := NonGenericKVPair{}
+	kv_pair_inner_generic := new(KVPair[uint64, KVPair[uint64, string]])
+	kv_pair_inner_non_generic := KVPair[uint64, NonGenericKVPair]{}
+	kv_pair_generic.Key = 1
+	kv_pair_partly_generic.Value = "generic_val"
+	kv_pair_non_generic.Key = 2
+	kv_pair_inner_generic.Key = 3
+	kv_pair_inner_generic.Value = kv_pair_generic
+	kv_pair_inner_non_generic.Key = 4
+	kv_pair_generic_ptr.Key = 0
+	return kv_pair_inner_generic.Value.Key
+}

--- a/internal/examples/unittest/struct_generic.go
+++ b/internal/examples/unittest/struct_generic.go
@@ -17,19 +17,43 @@ type NonGenericKVPair struct {
 	Value string
 }
 
+// buffer_size = 0 is an unbuffered channel
+func NewKVPair[K any, V any](Key K, Value V) KVPair[K, V] {
+	return KVPair[K, V]{
+		Key:   Key,
+		Value: Value,
+	}
+}
+
+// buffer_size = 0 is an unbuffered channel
+func NewKVPairRef[K any, V any](Key K, Value V) *KVPair[K, V] {
+	return &KVPair[K, V]{
+		Key:   Key,
+		Value: Value,
+	}
+}
+
+func (c *KVPair[K, V]) GetKey() K {
+	return c.Key
+}
+func (c *KVPair[K, V]) GetValue() V {
+	return c.Value
+}
+
 func testGenericStructs() uint64 {
-	kv_pair_generic := KVPair[uint64, string]{}
+	kv_pair_generic_define_inline := KVPair[uint64, string]{}
+	kv_pair_generic_from_func := NewKVPair[uint64, string](0, "str")
 	kv_pair_generic_ptr := KVPair[uint64, *uint64]{}
 	kv_pair_partly_generic := IndexedKVPair[uint64, string]{}
 	kv_pair_non_generic := NonGenericKVPair{}
 	kv_pair_inner_generic := new(KVPair[uint64, KVPair[uint64, string]])
 	kv_pair_inner_non_generic := KVPair[uint64, NonGenericKVPair]{}
-	kv_pair_generic.Key = 1
-	kv_pair_partly_generic.Value = "generic_val"
-	kv_pair_non_generic.Key = 2
+	kv_pair_generic_define_inline.Key = 1
+	kv_pair_partly_generic.Value = kv_pair_generic_from_func.GetValue()
+	kv_pair_non_generic.Key = *kv_pair_generic_ptr.GetValue()
 	kv_pair_inner_generic.Key = 3
-	kv_pair_inner_generic.Value = kv_pair_generic
+	kv_pair_inner_generic.Value = kv_pair_generic_from_func
 	kv_pair_inner_non_generic.Key = 4
-	kv_pair_generic_ptr.Key = 0
+	kv_pair_generic_ptr.Key = kv_pair_generic_define_inline.GetKey()
 	return kv_pair_inner_generic.Value.Key
 }

--- a/internal/examples/unittest/unittest.gold.v
+++ b/internal/examples/unittest/unittest.gold.v
@@ -953,39 +953,64 @@ Definition NonGenericKVPair := struct.decl [
   "Value" :: stringT
 ].
 
-Definition KVPair (K: ty) (V: ty) : struct.descriptor := struct.decl [
+Definition KVPair (K: ty) (V: ty) : descriptor := struct.decl [
   "Key" :: K;
   "Value" :: V;
   "Other" :: struct.t NonGenericKVPair
 ].
 
-Definition IndexedKVPair (K: ty) (V: ty) : struct.descriptor := struct.decl [
+Definition IndexedKVPair (K: ty) (V: ty) : descriptor := struct.decl [
   "Key" :: K;
   "Value" :: V;
   "Index" :: uint64T
 ].
 
+(* buffer_size = 0 is an unbuffered channel *)
+Definition NewKVPair (K:ty) (V:ty): val :=
+  rec: "NewKVPair" "Key" "Value" :=
+    struct.mk (KVPair K V) [
+      "Key" ::= "Key";
+      "Value" ::= "Value"
+    ].
+
+(* buffer_size = 0 is an unbuffered channel *)
+Definition NewKVPairRef (K:ty) (V:ty): val :=
+  rec: "NewKVPairRef" "Key" "Value" :=
+    struct.new (KVPair K V) [
+      "Key" ::= "Key";
+      "Value" ::= "Value"
+    ].
+
+Definition KVPair__GetKey (K:ty) (V:ty): val :=
+  rec: "KVPair__GetKey" "c" :=
+    struct.loadF (KVPair K V) "Key" "c".
+
+Definition KVPair__GetValue (K:ty) (V:ty): val :=
+  rec: "KVPair__GetValue" "c" :=
+    struct.loadF (KVPair K V) "Value" "c".
+
 Definition testGenericStructs: val :=
   rec: "testGenericStructs" <> :=
-    let: "kv_pair_generic" := struct.mk (KVPair uint64 string) [
+    let: "kv_pair_generic_define_inline" := struct.mk (KVPair uint64T stringT) [
     ] in
-    let: "kv_pair_generic_ptr" := struct.mk (KVPair uint64 ptrT) [
+    let: "kv_pair_generic_from_func" := NewKVPair uint64T stringT #0 #(str"str") in
+    let: "kv_pair_generic_ptr" := struct.mk (KVPair uint64T ptrT) [
     ] in
-    let: "kv_pair_partly_generic" := struct.mk (IndexedKVPair uint64 string) [
+    let: "kv_pair_partly_generic" := struct.mk (IndexedKVPair uint64T stringT) [
     ] in
     let: "kv_pair_non_generic" := struct.mk NonGenericKVPair [
     ] in
-    let: "kv_pair_inner_generic" := struct.alloc (KVPair uint64 (KVPair uint64 string)) (zero_val (struct.t (KVPair uint64 (KVPair uint64 string)))) in
-    let: "kv_pair_inner_non_generic" := struct.mk (KVPair uint64 NonGenericKVPair) [
+    let: "kv_pair_inner_generic" := struct.alloc (KVPair uint64T (struct.t (KVPair uint64T stringT))) (zero_val (struct.t (KVPair uint64T (struct.t (KVPair uint64T stringT))))) in
+    let: "kv_pair_inner_non_generic" := struct.mk (KVPair uint64T (struct.t NonGenericKVPair)) [
     ] in
-    struct.storeF (KVPair uint64 string) "Key" "kv_pair_generic" #1;;
-    struct.storeF (IndexedKVPair uint64 string) "Value" "kv_pair_partly_generic" #(str"generic_val");;
-    struct.storeF NonGenericKVPair "Key" "kv_pair_non_generic" #2;;
-    struct.storeF (KVPair uint64 (KVPair uint64 string)) "Key" "kv_pair_inner_generic" #3;;
-    struct.storeF (KVPair uint64 (KVPair uint64 string)) "Value" "kv_pair_inner_generic" "kv_pair_generic";;
-    struct.storeF (KVPair uint64 NonGenericKVPair) "Key" "kv_pair_inner_non_generic" #4;;
-    struct.storeF (KVPair uint64 ptrT) "Key" "kv_pair_generic_ptr" #0;;
-    struct.get (KVPair uint64 string) "Key" (struct.loadF (KVPair uint64 (KVPair uint64 string)) "Value" "kv_pair_inner_generic").
+    struct.storeF (KVPair uint64T stringT) "Key" "kv_pair_generic_define_inline" #1;;
+    struct.storeF (IndexedKVPair uint64T stringT) "Value" "kv_pair_partly_generic" (KVPair__GetValue uint64T stringT "kv_pair_generic_from_func");;
+    struct.storeF NonGenericKVPair "Key" "kv_pair_non_generic" (![uint64T] (KVPair__GetValue uint64T ptrT "kv_pair_generic_ptr"));;
+    struct.storeF (KVPair uint64T (struct.t (KVPair uint64T stringT))) "Key" "kv_pair_inner_generic" #3;;
+    struct.storeF (KVPair uint64T (struct.t (KVPair uint64T stringT))) "Value" "kv_pair_inner_generic" "kv_pair_generic_from_func";;
+    struct.storeF (KVPair uint64T (struct.t NonGenericKVPair)) "Key" "kv_pair_inner_non_generic" #4;;
+    struct.storeF (KVPair uint64T ptrT) "Key" "kv_pair_generic_ptr" (KVPair__GetKey uint64T stringT "kv_pair_generic_define_inline");;
+    struct.get (KVPair uint64T stringT) "Key" (struct.loadF (KVPair uint64T (struct.t (KVPair uint64T stringT))) "Value" "kv_pair_inner_generic").
 
 (* struct_method.go *)
 

--- a/internal/examples/unittest/unittest.gold.v
+++ b/internal/examples/unittest/unittest.gold.v
@@ -946,6 +946,47 @@ Definition stringLength: val :=
   rec: "stringLength" "s" :=
     StringLength "s".
 
+(* struct_generic.go *)
+
+Definition NonGenericKVPair := struct.decl [
+  "Key" :: uint64T;
+  "Value" :: stringT
+].
+
+Definition KVPair (K: ty) (V: ty) : struct.descriptor := struct.decl [
+  "Key" :: K;
+  "Value" :: V;
+  "Other" :: struct.t NonGenericKVPair
+].
+
+Definition IndexedKVPair (K: ty) (V: ty) : struct.descriptor := struct.decl [
+  "Key" :: K;
+  "Value" :: V;
+  "Index" :: uint64T
+].
+
+Definition testGenericStructs: val :=
+  rec: "testGenericStructs" <> :=
+    let: "kv_pair_generic" := struct.mk (KVPair uint64 string) [
+    ] in
+    let: "kv_pair_generic_ptr" := struct.mk (KVPair uint64 ptrT) [
+    ] in
+    let: "kv_pair_partly_generic" := struct.mk (IndexedKVPair uint64 string) [
+    ] in
+    let: "kv_pair_non_generic" := struct.mk NonGenericKVPair [
+    ] in
+    let: "kv_pair_inner_generic" := struct.alloc (KVPair uint64 (KVPair uint64 string)) (zero_val (struct.t (KVPair uint64 (KVPair uint64 string)))) in
+    let: "kv_pair_inner_non_generic" := struct.mk (KVPair uint64 NonGenericKVPair) [
+    ] in
+    struct.storeF (KVPair uint64 string) "Key" "kv_pair_generic" #1;;
+    struct.storeF (IndexedKVPair uint64 string) "Value" "kv_pair_partly_generic" #(str"generic_val");;
+    struct.storeF NonGenericKVPair "Key" "kv_pair_non_generic" #2;;
+    struct.storeF (KVPair uint64 (KVPair uint64 string)) "Key" "kv_pair_inner_generic" #3;;
+    struct.storeF (KVPair uint64 (KVPair uint64 string)) "Value" "kv_pair_inner_generic" "kv_pair_generic";;
+    struct.storeF (KVPair uint64 NonGenericKVPair) "Key" "kv_pair_inner_non_generic" #4;;
+    struct.storeF (KVPair uint64 ptrT) "Key" "kv_pair_generic_ptr" #0;;
+    struct.get (KVPair uint64 string) "Key" (struct.loadF (KVPair uint64 (KVPair uint64 string)) "Value" "kv_pair_inner_generic").
+
 (* struct_method.go *)
 
 Definition Point := struct.decl [

--- a/testdata/negative-tests/badgenerics2.go
+++ b/testdata/negative-tests/badgenerics2.go
@@ -1,5 +1,0 @@
-package example
-
-type Box[T any] struct { // ERROR generic named type
-	v T
-}

--- a/types.go
+++ b/types.go
@@ -302,16 +302,9 @@ func isAtomicPointerType(t types.Type) bool {
 	return false
 }
 
-func isNamedPtrType(t types.Type) bool {
-	if _, ok := t.(*types.Named); ok {
-		return true
-	}
-	return false
-}
-
-func isPointerToNamedPtrType(t types.Type) bool {
+func isPointerToNamedType(t types.Type) bool {
 	if t, ok := t.(*types.Pointer); ok {
-		return isNamedPtrType(t.Elem())
+		return isNamedType(t.Elem())
 	}
 	return false
 }
@@ -374,7 +367,7 @@ func (ctx Ctx) getStructInfo(t types.Type) (structTypeInfo, bool) {
 		t = pt.Elem()
 	}
 	if t, ok := t.(*types.Named); ok {
-		struct_coq_type := getStructDescriptor(ctx, t).(coq.StructType)
+		struct_coq_type := getStructType(ctx, t).(coq.StructType)
 		if structType, ok := t.Underlying().(*types.Struct); ok {
 			return structTypeInfo{
 				structCoqType:  struct_coq_type,

--- a/types.go
+++ b/types.go
@@ -199,6 +199,10 @@ func (ctx Ctx) coqType(e ast.Expr) coq.Type {
 		return ctx.coqFuncType(e)
 	case *ast.IndexExpr:
 		ctx.todo(e, "unsupported generic type instantiation")
+	case *ast.IndexListExpr:
+		// Type parameter list for generic struct
+		return ctx.coqTypeOfType(e, ctx.typeOf(e))
+
 	default:
 		ctx.unsupported(e, "unexpected type expr")
 	}
@@ -355,7 +359,9 @@ func (ctx Ctx) getStructInfo(t types.Type) (structTypeInfo, bool) {
 		t = pt.Elem()
 	}
 	if t, ok := t.(*types.Named); ok {
-		name := ctx.qualifiedName(t.Obj())
+		// For a generic struct, we have to call the descriptor function with type params,
+		// otherwise, this will just return the struct name.
+		name := getStructDescriptorFunction(ctx, t)
 		if structType, ok := t.Underlying().(*types.Struct); ok {
 			return structTypeInfo{
 				name:           name,


### PR DESCRIPTION
I did this by translating struct descriptors for structs with type parameters to be a function that takes the go types and returns a descriptor with the types resolved. This required replacing where we store the name of the struct with a call to
this function. This should not change how non-generic structs are translated.