### PR TITLE
Add Goose model for Go channels.

### DIFF
--- a/channel/README.md
+++ b/channel/README.md
@@ -1,0 +1,31 @@
+This directory contains a model for channels in Go for use in Perennial that has the following characteristics:
+1. It is implemented as a generic struct in Go.
+2. The struct stores a buffered ring queue that is used for buffered channels and 4 boolean flags that are used for unbuffered channel synchronization.
+3. Each method in the struct other than Len/Cap/Close branches on whether the buffer has capacity 0 to determine whether the channel is Unbuffered or Buffered. Buffered channels use logic very similar to the concurrent blocking queue here: https://github.com/mit-pdos/gokv/blob/main/tutorial/queue/queue.go and unbuffered channels have a more subtle barrier-like implementation
+4. There are TryReceive and TrySend functions that will be used by select statements and range for loops as described in the source code comments
+
+The code here is translated using Goose's preexisting support for struct generics and Go code that uses channels is then translated directly into Gooselang code that references the output from translating channel.go. 
+
+The tests in channel_test.go are the correctness based tests from https://go.dev/src/runtime/chanbarrier_test.go and https://go.dev/src/runtime/chan_test.go translated to this model from Go channels. These all passed except for TestSelfSelect. I documented the known edge cases in select statements that aren't quite modeled correctly.
+
+The unbuffered channel behavior in this model is described in the diagram below:
+
+```mermaid
+stateDiagram-v2
+	[*] --> Start: Create Channel
+    Start-->sender_ready: Sender arrives first
+    Start-->receiver_ready: Receiver arrives first
+    sender_ready-->receiver_done: Receiver completes exchange
+    receiver_ready-->sender_done: Sender completes exchange
+    receiver_done-->Start: Sender observes completed exchange
+    sender_done-->Start: Receiver observes completed exchange
+    Start-->closed
+    receiver_done-->closed_and_receiver_done: Close before exchange acknowledged
+    sender_done-->closed_and_sender_done: Close before exchange acknowledged
+    receiver_ready-->closed
+    sender_ready-->closed
+    closed_and_receiver_done --> closed: Sender observes completed exchange
+    closed_and_sender_done --> closed: Receiver observes completed exchange
+    closed-->[*]
+```
+

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -1,0 +1,565 @@
+package channel
+
+import (
+	"sync"
+)
+
+type Channel[T any] struct {
+	lock   *sync.Mutex
+	closed bool
+
+	// Values only used for buffered channels. The length of buffer being 0 is how we determine a
+	// channel is unbuffered. buffer is a circular queue that represents the channel's buffer
+	buffer []T
+	first  uint64
+	count  uint64
+
+	// Values only used for unbuffered channels
+	v              T
+	receiver_ready bool
+	sender_ready   bool
+	receiver_done  bool
+	sender_done    bool
+}
+
+// buffer_size = 0 is an unbuffered channel
+func NewChannel[T any](buffer_size uint64) Channel[T] {
+	return Channel[T]{
+		buffer: make([]T, buffer_size),
+		lock:   new(sync.Mutex),
+		first:  0,
+		count:  0,
+	}
+}
+
+// buffer_size = 0 is an unbuffered channel
+func NewChannelRef[T any](buffer_size uint64) *Channel[T] {
+	return &Channel[T]{
+		buffer: make([]T, buffer_size),
+		lock:   new(sync.Mutex),
+		first:  0,
+		count:  0,
+	}
+}
+
+// c.Send(val)
+//
+// is equivalent to:
+//
+// c <- val
+func (c *Channel[T]) Send(val T) {
+	if c == nil {
+		// Block forever
+		for {
+		}
+	}
+	var buffer_size uint64 = uint64(len(c.buffer))
+	// Buffered channel. In this case we can simply wait for space in the queue and queue our value.
+	if buffer_size != 0 {
+		for {
+			c.lock.Lock()
+			if c.closed {
+				panic("send on closed channel")
+			}
+			// No room to buffer the value
+			if c.count >= buffer_size {
+				c.lock.Unlock()
+				continue
+			}
+			// emplace the value in the circular queue
+			var last uint64 = (c.first + c.count) % buffer_size
+			c.buffer[last] = val
+			c.count += 1
+			c.lock.Unlock()
+			break
+		}
+		// Unbuffered channel. This is more complex since the sender must wait for a receiver to be
+		//  waiting and also wait for the receiver to acknowledge that it has received the value
+		// before moving on.
+	} else {
+
+		// Set to true if the receiver arrives before the sender
+		var return_early = false
+
+		// Wait for either
+		// 1. A receiver waiting for a value to be sent
+		// 2. No channel operations are in progress, meaning we can communicate that we are a
+		// waiting sender to the next receiver that arrives.
+		for {
+			c.lock.Lock()
+			if c.closed {
+				panic("send on closed channel")
+			}
+			// Receiver waiting
+			if c.receiver_ready {
+				// Reset the receiver's waiting flag
+				c.receiver_ready = false
+				// Tell the receiver we have sent a value
+				c.sender_done = true
+				// Tell the receiver the value we are sending
+				c.v = val
+				c.lock.Unlock()
+				return_early = true
+				break
+			}
+			// No other senders/receivers have initiated a channel exchange so we can.
+			if !c.receiver_ready && !c.sender_ready && !c.receiver_done && !c.sender_done {
+				// Send our value
+				c.v = val
+				// Tell receivers we have sent a value
+				c.sender_ready = true
+				c.lock.Unlock()
+				break
+			}
+			c.lock.Unlock()
+		}
+
+		// If we arrived second, we still have to wait for the receiver to acknowledge that they
+		// have received our value so that the sender cannot continue and potentially close the
+		// channel before the receiver has completed the exchange, which would differ from the
+		// behavior of Go channels.
+		if return_early {
+			for {
+				c.lock.Lock()
+				if !c.sender_done {
+					c.lock.Unlock()
+					break
+				}
+				c.lock.Unlock()
+			}
+			return
+		}
+		// We have arrived first, wait for the receiver to acknowledge that they have received our
+		// value.
+		for {
+			c.lock.Lock()
+			// We need to check closed again here. If we queued are value before another channel
+			// closed, we will must panic.
+			if c.closed {
+				panic("send on closed channel")
+			}
+			if c.receiver_done {
+				c.receiver_done = false
+				c.lock.Unlock()
+				break
+			}
+			c.lock.Unlock()
+		}
+	}
+}
+
+// Equivalent to:
+// value, ok := <-c
+// Notably, this requires the user to consume the ok bool which is not actually required with Go
+// channels. This should be able to be solved by adding an overload wrapper that discards the ok
+// bool.
+func (c *Channel[T]) Receive() (T, bool) {
+	if c == nil {
+		// Block forever
+		for {
+		}
+	}
+	var ret_val T
+	var buffer_size uint64 = uint64(len(c.buffer))
+	var closed = false
+
+	// Buffered channel, we can simply block until a value is in the buffer then dequeue it from
+	// the buffer.
+	if buffer_size != 0 {
+		for {
+			c.lock.Lock()
+			if c.closed && c.count == 0 {
+				c.lock.Unlock()
+				closed = true
+				break
+			}
+			if c.count == 0 {
+				c.lock.Unlock()
+				continue
+			}
+			ret_val = c.buffer[c.first]
+			c.first = (c.first + 1) % buffer_size
+			c.count -= 1
+			c.lock.Unlock()
+			break
+		}
+		return ret_val, !closed
+		// Unbuffered channel. This logic is more complex since we need to make sure the exchange
+		// doesn't begin until a sender is ready and doesn't end until the sender knows the
+		// receiver has received the value.
+	} else {
+
+		var return_early = false
+		for {
+			c.lock.Lock()
+			if c.closed {
+				c.lock.Unlock()
+				closed = true
+				break
+			}
+			// Sender is waiting
+			if c.sender_ready {
+				// Reset sender waiting flag
+				c.sender_ready = false
+				// Inform the sender we have received the value
+				c.receiver_done = true
+				// Save the value
+				ret_val = c.v
+				c.lock.Unlock()
+				return_early = true
+				break
+			}
+			// No channel operations are in progress so we can initiate an exchange
+			if !c.receiver_ready && !c.sender_ready && !c.receiver_done && !c.sender_done {
+				// Inform the next sender that we are ready to receive.
+				c.receiver_ready = true
+				c.lock.Unlock()
+				break
+			}
+			c.lock.Unlock()
+		}
+		if closed {
+			return ret_val, !closed
+		}
+		// If the sender arrived first, we still must wait for them to acknowledge that the .
+		// exchange is complete.
+		if return_early {
+			for {
+				c.lock.Lock()
+				if !c.receiver_done {
+					c.lock.Unlock()
+					break
+				}
+				c.lock.Unlock()
+			}
+			return ret_val, !closed
+		}
+		// Receiver arrived first, wait for sender to arrive and queue value for us.
+		for {
+			c.lock.Lock()
+			if c.closed {
+				c.lock.Unlock()
+				closed = true
+				break
+			}
+			if c.sender_done {
+				// Reset sender flag
+				c.sender_done = false
+				// Save value
+				ret_val = c.v
+				c.lock.Unlock()
+				break
+			}
+			c.lock.Unlock()
+		}
+		return ret_val, !closed
+	}
+}
+
+// c.Close()
+//
+// is equivalent to:
+//
+// close(c)
+func (c *Channel[T]) Close() {
+	if c == nil {
+		panic("close of nil channel")
+	}
+	c.lock.Lock()
+	if c.closed {
+		panic("close of closed channel")
+	}
+	// For Unbuffered channels, we set these false since there may be waiting senders and receivers
+	// before Close() is called. This will ensure that the waiting senders panic and waiting
+	// receivers return the null value. For buffered channels, senders check for closed on every
+	// loop iteration while waiting for a value to become available and receivers can simply
+	// dequeue values without checking for closed since real Go buffered channels do not return the
+	// null value on a closed channel receive until there are no more buffered values.
+	c.receiver_ready = false
+	c.sender_ready = false
+	c.closed = true
+	c.lock.Unlock()
+}
+
+// v := c.ReceiveDiscardOk
+//
+// is equivalent to:
+// v := c<-
+// It seems like Go requires ignored return values to be annotated with _ but channels don't
+// require this so this will need to be translated.
+func (c *Channel[T]) ReceiveDiscardOk() T {
+	var return_val T
+	return_val, _ = c.Receive()
+	return return_val
+}
+
+// This:
+//
+//	for {
+//		selected, val, ok := ch.TryReceive()
+//		if !ok {
+//			break
+//		}
+//		if selected {
+//			<body>
+//		}
+//	}
+//
+// is equivalent to:
+//
+//	for v := <-ch {
+//			<body>
+//	}
+//
+// This:
+//
+//	selected, val, ok := c.TryReceive()
+//	if selected {
+//		<first case body>
+//	} else {
+//		selected = c.TrySend(0)
+//		if selected {
+//			<second case body>
+//		} else {
+//			<default block body>
+//		}
+//	}
+//
+// is equivalent to:
+//
+//	select {
+//		case <-c:
+//			<first case body>
+//		case c <- 0:
+//			<second case body>
+//		default:
+//			<default body>
+//		}
+//
+// This:
+//
+//	for {
+//		selected, val, ok := c.TryReceive()
+//		if selected {
+//			<first case body>
+//			break
+//		} else {
+//			selected = c.TrySend(0)
+//			if selected {
+//				<second case body>
+//				break
+//			}
+//		}
+//	}
+//
+// is equivalent to:
+//
+//	select {
+//		case <-c:
+//			<first case body>
+//		case c <- 0:
+//			<second case body>
+//		}
+//
+// Note: Technically speaking, Go only compiles select statements to if/else blocks when there is 1
+// case statement with a default block. When there are multiple statements, the Go code will choose
+// a case statement with uniform probability among all "selectable" statements, meaning those that
+// have a waiting sender/receiver on the other end and receives on closed channels. Since threading
+// behavior means that it already can't be assumed with certainty which blocks are selected, the if/
+// else block translation should be equivalent from a correctness perspective. There are at least 2
+// notable unsound property with this approach:
+// 1. Once a channel is closed, a receive case statement on said channel will always be selectable.
+// This means that after the channel is closed, this case statement will always be selected above
+// other statements below. This is considered an antipattern in the Go community and it is
+// recommended that if a select case permits a closed channel receive, the channel is set to nil so
+// that the statement will no longer be selectable. We can prevent this with the specfication by
+// forcing the receiver to renounce receive ownership after receiving on a closed channel.
+// 2. When there are multiple blocking select statements(no default case) with 2 cases: a send and
+// a receive statement on the same unbuffered channel running concurrently, this model's
+// implementation will livelock since neither goroutine will communicate to the other that it is
+// waiting with a matching send/receive statement, so TrySend/TryReceive will fail repeatedly. See
+// TestSelfSelect in https://go.dev/src/runtime/chan_test.go for the unit test that brought
+// attention to this issue.
+//
+// We will eventually be able to make this model sound for 1. once we have support for random
+// permutations using a similar approach to dynamic select statements in the reflect package but for
+// now our specification will prevent code that isn't equivalent from being verified which should
+// be good enough.
+//
+// For 2, I believe that if we have support for random numbers we can implement blocking select
+// statements with unbuffered channels by randomly selecting a case with an unbuffered channel
+// using the following algorithm:
+// 1. Attempt each case's channel operation with TrySend/TryReceive. If one of them succeeds,
+// select this case and execute its block
+// 2. For each case statement with an unbuffered channel, lock the associated channel
+// 3. Randomly select an unbuffered channel and set the sender_ready or receiver_ready flag for a
+// Send/Receive operation respectively.
+// 4. Unlock all of the unbuffered channels
+// 5. Lock the channel that was chosen in step 3 and if the ready flag has been set to false,
+// continue the send/receive using the same procedure as Send()/Receive(), unlock the channel and
+// execute the associated case block
+// 6. Otherwise, unlock the channel and go back to step 1.
+// This is not particularly graceful and relies on the sending thread being preempted in between
+// steps 4 and 5 and the goroutine with the goroutine executing the matching select statement
+// acquiring the lock in between but it should eventually be able to make progress eventually. This
+// is indeed a tough edge case for real channels as well as it breaks an otherwise powerful
+// invariant as described in the comment on line 10 in the runtime
+// implementation(https://go.dev/src/runtime/chan.go), so I don't think there will be a
+// particularly graceful solution here. I also don't know of any useful patterns that would require
+// a select statement of this sort so it may be worth it to fix this problem lazily i.e. if/when a
+// use case happens to call for it in the future.
+//
+// Note: The above code technically makes it so the top block's expression variables
+// are in scope in all of the other blocks. This would error in the Go code before it is translated
+// so this shouldn't matter for practical purposes.
+func (c *Channel[T]) TryReceive() (bool, T, bool) {
+	var ret_val T
+	if c == nil {
+		return false, ret_val, false
+	}
+	var buffer_size uint64 = uint64(len(c.buffer))
+	var closed = false
+	var selected = false
+	// Buffered channel
+	if buffer_size != 0 {
+		c.lock.Lock()
+		// No values available to dequeue, don't select unless channel is closed.
+		if c.count == 0 {
+			if c.closed {
+				closed = true
+				selected = true
+			}
+			c.lock.Unlock()
+		} else {
+			// Value is available, select and dequeue value
+			ret_val = c.buffer[c.first]
+			c.first = (c.first + 1) % buffer_size
+			c.count -= 1
+			selected = true
+			c.lock.Unlock()
+		}
+		return selected, ret_val, !closed
+		// Unbuffered channel. This logic is more complex since we need to make sure the exchange
+		// doesn't occur unless a sender is ready and doesn't end until the sender knows the
+		// receiver has received the value.
+	} else {
+		c.lock.Lock()
+		if c.closed {
+			closed = true
+			selected = true
+		} else {
+			// Sender is waiting, get the value.
+			if c.sender_ready {
+				// Reset the sender's waiting flag
+				c.sender_ready = false
+				// Inform the sender that we have the value
+				c.receiver_done = true
+				// Save the value
+				ret_val = c.v
+				selected = true
+			}
+		}
+		c.lock.Unlock()
+		if closed {
+			return selected, ret_val, !closed
+		}
+		// If we received a value, wait until the sender knows that we received the value to
+		// complete the exchange.
+		if selected {
+			for {
+				c.lock.Lock()
+				if !c.receiver_done {
+					c.lock.Unlock()
+					break
+				}
+				c.lock.Unlock()
+			}
+		}
+		return selected, ret_val, !closed
+	}
+}
+
+// See comment in TryReceive for how this is used to translate selects.
+func (c *Channel[T]) TrySend(val T) bool {
+	// Nil is not selectable
+	if c == nil {
+		return false
+	}
+	var selected = false
+	var buffer_size uint64 = uint64(len(c.buffer))
+
+	// Buffered channel
+	if buffer_size != 0 {
+		c.lock.Lock()
+		if c.closed {
+			panic("send on closed channel")
+		}
+		// If we have room, buffer our value
+		if !(c.count >= buffer_size) {
+			var last uint64 = (c.first + c.count) % buffer_size
+			c.buffer[last] = val
+			c.count += 1
+			selected = true
+		}
+		c.lock.Unlock()
+		return selected
+		// Unbuffered channel
+	} else {
+		c.lock.Lock()
+		if c.closed {
+			panic("send on closed channel")
+		}
+
+		// If we're not closed and a receiver is waiting, we can send them the value
+		if c.receiver_ready {
+			c.receiver_ready = false
+			c.sender_done = true
+			c.v = val
+			selected = true
+		}
+		c.lock.Unlock()
+		// This is necessary to make sure that the receiver has consumed our sent value. If we
+		// don't do this, a sender can unblock and potentially close the channel before the
+		// receiver has had a chance to consume it which would not be the same behavior as Go
+		// channels.
+		if selected {
+			for {
+				c.lock.Lock()
+				if !c.sender_done {
+					break
+				}
+				c.lock.Unlock()
+			}
+		}
+		return selected
+	}
+}
+
+// c.Len()
+//
+// is equivalent to:
+// len(c)
+//
+// This might not be worth specifying since it is hard to make good use of channel length
+// semantics.
+func (c *Channel[T]) Len() uint64 {
+	if c == nil {
+		return 0
+	}
+	var chan_len uint64 = 0
+	c.lock.Lock()
+	chan_len = c.count
+	c.lock.Unlock()
+	return chan_len
+}
+
+// c.Cap()
+//
+// is equivalent to:
+// cap(c)
+func (c *Channel[T]) Cap() uint64 {
+	if c == nil {
+		return 0
+	}
+	return uint64(len(c.buffer))
+}

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -1,0 +1,512 @@
+package channel_test
+
+/*
+Tests to demonstrate Go's behavior on various subtle examples.
+*/
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/goose-lang/goose/channel"
+)
+
+// The channel tests below are for the Goose model of channels that is implemented as a Go
+// struct. The tests are hand translated versions of correctness based tests in
+// https://go.dev/src/runtime/chan_test.go https://go.dev/src/runtime/chanbarrier_test.go
+func TestChan(t *testing.T) {
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(4))
+	var N uint64 = 200
+	if testing.Short() {
+		N = 20
+	}
+	for chanCap := uint64(0); chanCap < N; chanCap++ {
+		{
+			// Ensure that receive from empty chan blocks.
+			c := channel.NewChannelRef[uint64](chanCap)
+			recv1 := false
+			go func() {
+				_, _ = c.Receive()
+				recv1 = true
+			}()
+			recv2 := false
+			go func() {
+				_, _ = c.Receive()
+				recv2 = true
+			}()
+			time.Sleep(time.Millisecond)
+			if recv1 || recv2 {
+				t.Fatalf("chan[%d]: receive from empty chan", chanCap)
+			}
+			// Ensure that non-blocking receive does not block.
+
+			selected, _, _ := c.TryReceive()
+			if selected {
+				t.Fatalf("chan[%d]: receive from empty chan", chanCap)
+			}
+
+			selected, _, _ = c.TryReceive()
+			if selected {
+				t.Fatalf("chan[%d]: receive from empty chan", chanCap)
+			}
+			c.Send(0)
+			c.Send(0)
+		}
+
+		{
+			// Ensure that send to full chan blocks.
+			c := channel.NewChannelRef[uint64](chanCap)
+			for i := uint64(0); i < chanCap; i++ {
+				c.Send(i)
+			}
+			sent := uint32(0)
+			go func() {
+				c.Send(0)
+				atomic.StoreUint32(&sent, 1)
+			}()
+			time.Sleep(time.Millisecond)
+			if atomic.LoadUint32(&sent) != 0 {
+				t.Fatalf("chan[%d]: send to full chan", chanCap)
+			}
+			selected := c.TrySend(0)
+			if selected {
+				t.Fatalf("chan[%d]: send to full chan", chanCap)
+			}
+			c.Receive()
+		}
+
+		{
+			// Ensure that we receive 0 from closed chan.
+			c := channel.NewChannelRef[uint64](chanCap)
+			for i := uint64(0); i < chanCap; i++ {
+				c.Send(i)
+			}
+			c.Close()
+			for i := uint64(0); i < chanCap; i++ {
+				v, _ := c.Receive()
+				if v != i {
+					t.Fatalf("chan[%d]: received %v, expected %v", chanCap, v, i)
+				}
+			}
+			if v, _ := c.Receive(); v != 0 {
+				t.Fatalf("chan[%d]: received %v, expected %v", chanCap, v, 0)
+			}
+			if v, ok := c.Receive(); v != 0 || ok {
+				t.Fatalf("chan[%d]: received %v/%v, expected %v/%v", chanCap, v, ok, 0, false)
+			}
+		}
+
+		{
+			// Ensure that close unblocks receive.
+			c := channel.NewChannelRef[uint64](chanCap)
+			done := channel.NewChannelRef[bool](0)
+			go func() {
+				v, ok := c.Receive()
+				done.Send(v == 0 && ok == false)
+			}()
+			time.Sleep(time.Millisecond)
+			c.Close()
+			actually_done, _ := done.Receive()
+			if !actually_done {
+				t.Fatalf("chan[%d]: received non zero from closed chan", chanCap)
+			}
+		}
+
+		{
+			// Send 100 integers,
+			// ensure that we receive them non-corrupted in FIFO order.
+			c := channel.NewChannelRef[uint64](chanCap)
+			go func() {
+				for i := uint64(0); i < 100; i++ {
+					c.Send(i)
+				}
+			}()
+			for i := uint64(0); i < 100; i++ {
+				v, _ := c.Receive()
+				if v != i {
+					t.Fatalf("chan[%d]: received %v, expected %v", chanCap, v, i)
+				}
+			}
+
+			// Same, but using recv2.
+			go func() {
+				for i := uint64(0); i < 100; i++ {
+					c.Send(i)
+				}
+			}()
+			for i := uint64(0); i < 100; i++ {
+				v, ok := c.Receive()
+				if !ok {
+					t.Fatalf("chan[%d]: receive failed, expected %v", chanCap, i)
+				}
+				if v != i {
+					t.Fatalf("chan[%d]: received %v, expected %v", chanCap, v, i)
+				}
+			}
+
+			// Send 1000 integers in 4 goroutines,
+			// ensure that we receive what we send.
+			const P = 4
+			const L uint64 = 1000
+			for p := 0; p < P; p++ {
+				go func() {
+					for i := uint64(0); i < L; i++ {
+						c.Send(i)
+					}
+				}()
+			}
+			done := channel.NewChannelRef[map[uint64]uint64](chanCap)
+			for p := uint64(0); p < P; p++ {
+				go func() {
+					recv := make(map[uint64]uint64)
+					for i := uint64(0); i < L; i++ {
+						v, _ := c.Receive()
+						recv[v] = recv[v] + 1
+					}
+					done.Send(recv)
+				}()
+			}
+			recv := make(map[uint64]uint64)
+			for p := uint64(0); p < P; p++ {
+				received_val, _ := done.Receive()
+				for k, v := range received_val {
+					recv[k] = recv[k] + v
+				}
+			}
+			if uint64(len(recv)) != L {
+				t.Fatalf("chan[%d]: received %v values, expected %v", chanCap, len(recv), L)
+			}
+			for _, v := range recv {
+				if v != P {
+					t.Fatalf("chan[%d]: received %v values, expected %v", chanCap, v, P)
+				}
+			}
+		}
+
+		{
+			// Test len/cap.
+			c := channel.NewChannelRef[uint64](chanCap)
+			if c.Len() != uint64(0) || c.Cap() != chanCap {
+				t.Fatalf("chan[%d]: bad len/cap, expect %v/%v, got %v/%v", chanCap, 0, chanCap, c.Len(), c.Cap())
+			}
+			for i := uint64(0); i < chanCap; i++ {
+				c.Send(i)
+			}
+			if c.Len() != chanCap || c.Cap() != chanCap {
+				t.Fatalf("chan[%d]: bad len/cap, expect %v/%v, got %v/%v", chanCap, chanCap, chanCap, c.Len(), c.Cap())
+			}
+		}
+	}
+}
+
+func TestNonblockRecvRace(t *testing.T) {
+	var n uint64 = 10000
+	if testing.Short() {
+		n = 100
+	}
+	for i := uint64(0); i < n; i++ {
+		c := channel.NewChannelRef[uint64](1)
+		c.Send(1)
+		go func() {
+			selected, _, _ := c.TryReceive()
+			if !selected {
+				t.Error("chan is not ready")
+			}
+		}()
+		c.Close()
+		c.Receive()
+		if t.Failed() {
+			return
+		}
+	}
+}
+func TestMultiConsumer(t *testing.T) {
+	const nwork uint64 = 23
+	const niter uint64 = 271828
+
+	pn := []uint64{2, 3, 7, 11, 13, 17, 19, 23, 27, 31}
+
+	q := channel.NewChannelRef[uint64](nwork * 3)
+	r := channel.NewChannelRef[uint64](nwork * 3)
+
+	// workers
+	var wg sync.WaitGroup
+	for i := uint64(0); i < nwork; i++ {
+		wg.Add(1)
+		go func(w uint64) {
+			for {
+				selected, val, ok := q.TryReceive()
+				if !ok {
+					break
+				}
+				if selected {
+					if pn[w%uint64(len(pn))] == val {
+						runtime.Gosched()
+					}
+					r.Send(val)
+				}
+			}
+			wg.Done()
+		}(i)
+	}
+
+	// feeder & closer
+	var expect uint64 = 0
+	go func() {
+		for i := uint64(0); i < niter; i++ {
+			v := pn[i%uint64(len(pn))]
+			expect += v
+			q.Send(v)
+		}
+		q.Close() // no more work
+		wg.Wait() // workers done
+		r.Close() // ... so there can be no more results
+	}()
+
+	// consume & check
+	var n uint64 = 0
+	var s uint64 = 0
+	for {
+		selected, val, ok := r.TryReceive()
+		if !ok {
+			break
+		}
+		if selected {
+			n++
+			s += val
+		}
+	}
+	if n != niter || s != expect {
+		t.Errorf("Expected sum %d (got %d) from %d iter (saw %d)",
+			expect, s, niter, n)
+	}
+}
+
+type response struct {
+}
+
+type myError struct {
+}
+
+func (myError) Error() string { return "" }
+
+func doRequest(useSelect bool) (*response, error) {
+	type async struct {
+		resp *response
+		err  error
+	}
+	ch := channel.NewChannelRef[*async](0)
+	done := channel.NewChannelRef[struct{}](0)
+
+	if useSelect {
+		go func() {
+			for {
+				selected := ch.TrySend(&async{resp: nil, err: myError{}})
+				if selected {
+					break
+				} else {
+					selected, _, _ := done.TryReceive()
+					if selected {
+						break
+					}
+				}
+			}
+		}()
+	} else {
+		go func() {
+			ch.Send(&async{resp: nil, err: myError{}})
+		}()
+	}
+
+	var r *async = ch.ReceiveDiscardOk()
+	runtime.Gosched()
+	return r.resp, r.err
+}
+
+func TestChanSendSelectBarrier(t *testing.T) {
+	t.Parallel()
+	testChanSendBarrier(true)
+}
+
+func TestChanSendBarrier(t *testing.T) {
+	t.Parallel()
+	testChanSendBarrier(false)
+}
+
+func testChanSendBarrier(useSelect bool) {
+	var wg sync.WaitGroup
+	outer := 10
+	inner := 100
+	if testing.Short() || runtime.GOARCH == "wasm" {
+		outer = 10
+		inner = 100
+	}
+	for i := 0; i < outer; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var garbage []byte
+			for j := 0; j < inner; j++ {
+				_, err := doRequest(useSelect)
+				_, ok := err.(myError)
+				if !ok {
+					panic(1)
+				}
+				garbage = makeByte()
+			}
+			_ = garbage
+		}()
+	}
+	wg.Wait()
+}
+
+//go:noinline
+func makeByte() []byte {
+	return make([]byte, 1<<10)
+}
+
+// This test checks that select acts on the state of the channels at one
+// moment in the execution, not over a smeared time window.
+// In the test, one goroutine does:
+//
+//	create c1, c2
+//	make c1 ready for receiving
+//	create second goroutine
+//	make c2 ready for receiving
+//	make c1 no longer ready for receiving (if possible)
+//
+// The second goroutine does a non-blocking select receiving from c1 and c2.
+// From the time the second goroutine is created, at least one of c1 and c2
+// is always ready for receiving, so the select in the second goroutine must
+// always receive from one or the other. It must never execute the default case.
+func TestNonblockSelectRace(t *testing.T) {
+	n := 100000
+	if testing.Short() {
+		n = 1000
+	}
+	done := channel.NewChannelRef[bool](0)
+	for i := 0; i < n; i++ {
+		c1 := channel.NewChannelRef[int](1)
+		c2 := channel.NewChannelRef[int](1)
+		c1.Send(1)
+		go func() {
+			selected, _, _ := c1.TryReceive()
+			if selected {
+
+			} else {
+				selected, _, _ = c2.TryReceive()
+				if selected {
+
+				} else {
+					done.Send(false)
+					return
+				}
+			}
+			done.Send(true)
+		}()
+		c2.Send(1)
+		c1.TryReceive()
+		val := done.ReceiveDiscardOk()
+		if !val {
+			t.Fatal("no chan is ready")
+		}
+	}
+}
+
+// Same as TestNonblockSelectRace, but close(c2) replaces c2 <- 1.
+func TestNonblockSelectRace2(t *testing.T) {
+	n := 100000
+	if testing.Short() {
+		n = 1000
+	}
+	done := channel.NewChannelRef[bool](0)
+	for i := 0; i < n; i++ {
+		c1 := channel.NewChannelRef[int](1)
+		c2 := channel.NewChannelRef[int](1)
+		c1.Send(1)
+		go func() {
+			selected, _, _ := c1.TryReceive()
+			if selected {
+
+			} else {
+				selected, _, _ = c2.TryReceive()
+				if selected {
+
+				} else {
+					done.Send(false)
+					return
+				}
+			}
+			done.Send(true)
+		}()
+		c2.Close()
+		c1.TryReceive()
+		val := done.ReceiveDiscardOk()
+		if !val {
+			t.Fatal("no chan is ready")
+		}
+	}
+}
+
+// This tests a case where real Go channels currently have different behavior from the model,
+// so the test does not pass for the model. The case is where there are 2 separate Goroutines
+// executing select statements with a send and receive case, all on the same unbuffered
+// channel. These statements should "match" and eventually this code should make progress but
+// this will likely be a challenge to handle in a way that is semantically equivalent to Go
+// channels.
+// FIXME: Uncomment once we have support for this
+/*func TestSelfSelect(t *testing.T) {
+	// Ensure that send/recv on the same chan in select
+	// does not crash nor deadlock.
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(2))
+	for _, chanCap := range []uint64{0, 10} {
+		var wg sync.WaitGroup
+		wg.Add(2)
+		c := channel.NewChannelRef[uint64](uint64(chanCap))
+		for p := uint64(0); p < 2; p++ {
+			p := p
+			go func() {
+				defer wg.Done()
+				for i := uint64(0); i < 1000; i++ {
+					if p == 0 || i%2 == 0 {
+						for {
+							selected := c.TrySend(p)
+							if selected {
+								break
+							} else {
+								selected, v, _ := c.TryReceive()
+								if selected {
+									if chanCap == 0 && v == p {
+										t.Errorf("self receive")
+										return
+									}
+									break
+								}
+							}
+						}
+					} else {
+						for {
+							selected, v, _ := c.TryReceive()
+							if selected {
+								if chanCap == 0 && v == p {
+									t.Errorf("self receive")
+									return
+								}
+								break
+							} else {
+								selected := c.TrySend(p)
+								if selected {
+									break
+								}
+							}
+						}
+					}
+				}
+			}()
+		}
+		wg.Wait()
+	}
+} */


### PR DESCRIPTION
This model has the following characteristics:
1. It is implemented as a generic struct in Go.
2. The struct stores a buffered ring queue that is used for buffered channels and 4 boolean flags that are used for unbuffered channel synchronization.
3. Each method in the struct other than Len/Cap/Close branches on whether the buffer has capacity 0 to determine whether the channel is Unbuffered or Buffered. Buffered channels use logic very similar to the concurrent blocking queue here: https://github.com/mit-pdos/gokv/blob/main/tutorial/queue/queue.go and unbuffered channels have a more subtle barrier-like implementation
4. There are TryReceive and TrySend functions that will be used by select statements and range for loops as described in the source code comments

I described the intended translation in the comments which will come in a later PR

I tested the model by copying the correctness based tests from https://go.dev/src/runtime/chanbarrier_test.go and https://go.dev/src/runtime/chan_test.go. These all passed except for TestSelfSelect. I documented the known edge cases in select statements that aren't quite modeled correctly.

This PR will depend on support for struct generics in the Goose translator so I will get review and merge the PR for those before this but figured I'd start getting feedback on this one as well.

The unbuffered channel behavior in this model is described in the diagram below:

```mermaid
stateDiagram-v2
	[*] --> Start: Create Channel
    Start-->sender_ready: Sender arrives first
    Start-->receiver_ready: Receiver arrives first
    sender_ready-->receiver_done: Receiver completes exchange
    receiver_ready-->sender_done: Sender completes exchange
    receiver_done-->Start: Sender observes completed exchange
    sender_done-->Start: Receiver observes completed exchange
    Start-->closed
    receiver_done-->closed_and_receiver_done: Close before exchange acknowledged
    sender_done-->closed_and_sender_done: Close before exchange acknowledged
    receiver_ready-->closed
    sender_ready-->closed
    closed_and_receiver_done --> closed: Sender observes completed exchange
    closed_and_sender_done --> closed: Receiver observes completed exchange
    closed-->[*]
```

