### PR TITLE
Support for channels in Goose translator

### DIFF
--- a/goose.go
+++ b/goose.go
@@ -695,7 +695,7 @@ func (ctx Ctx) methodExpr(call *ast.CallExpr) coq.Expr {
 		// the model is made using generic structs which don't allow you to define methods
 		// a struct without the type parameter.
 		if f.Name == "close" {
-			chan_type, ok := ctx.typeOf(args[0]).(*types.Chan)
+			chan_type, ok := ctx.typeOf(args[0]).Underlying().(*types.Chan)
 			if ok {
 				typeArgs = append(typeArgs, ctx.coqTypeOfType(args[0], chan_type.Elem()))
 

--- a/goose.go
+++ b/goose.go
@@ -690,6 +690,17 @@ func (ctx Ctx) methodExpr(call *ast.CallExpr) coq.Expr {
 		// XXX: this could be a struct field of type `func()`; right now we
 		// don't support generic structs, so code with a generic function field
 		// will be rejected. But, in the future, that might change.
+
+		// We technically need to pass the channel's type in to the close function because
+		// the model is made using generic structs which don't allow you to define methods
+		// a struct without the type parameter.
+		if f.Name == "close" {
+			chan_type, ok := ctx.typeOf(args[0]).(*types.Chan)
+			if ok {
+				typeArgs = append(typeArgs, ctx.coqTypeOfType(args[0], chan_type.Elem()))
+
+			}
+		}
 		retExpr = ctx.newCoqCallTypeArgs(ctx.identExpr(f), typeArgs, args)
 	case *ast.SelectorExpr:
 		retExpr = ctx.selectorMethod(f, call)
@@ -739,6 +750,19 @@ func (ctx Ctx) makeExpr(args []ast.Expr) coq.CallExpr {
 			ctx.coqTypeOfType(args[0], ty.Key()),
 			ctx.coqTypeOfType(args[0], ty.Elem()),
 			coq.UnitLiteral{})
+	case *types.Chan:
+		// For unbuffered channels, we explicitly pass 0, otherwise pass the buffer size.
+		buffer_size := 0
+		if len(args) > 1 {
+			if e, ok := args[1].(*ast.BasicLit); ok {
+				if e.Kind == token.INT {
+					buffer_size, _ = strconv.Atoi(e.Value)
+				}
+			}
+		}
+		return coq.NewCallExpr(coq.GallinaIdent("NewChannelRef"),
+			ctx.coqTypeOfType(args[0], ty.Elem()),
+			coq.IntLiteral{Value: uint64(buffer_size)})
 	default:
 		ctx.unsupported(args[0],
 			"make type should be slice or map, got %v", ty)
@@ -1148,6 +1172,18 @@ func (ctx Ctx) unaryExpr(e *ast.UnaryExpr) coq.Expr {
 		// e is something else
 		return ctx.refExpr(e.X)
 	}
+	if e.Op == token.ARROW {
+		// If we are using the ok variable that <- can return optionally, we have a different
+		// function in the model.
+		tuple_type, ok := ctx.typeOf(e).(*types.Tuple)
+		if ok {
+			return coq.NewCallExpr(coq.GallinaIdent("Channel__Receive"), ctx.coqTypeOfType(e, tuple_type.At(0).Type()), ctx.expr(e.X))
+		} else {
+
+			return coq.NewCallExpr(coq.GallinaIdent("Channel__ReceiveDiscardOk"), ctx.coqTypeOfType(e, ctx.typeOf(e)), ctx.expr(e.X))
+		}
+
+	}
 	ctx.unsupported(e, "unary expression %s", e.Op)
 	return nil
 }
@@ -1205,6 +1241,9 @@ func (ctx Ctx) identExpr(e *ast.Ident) coq.Expr {
 			return coq.True
 		case "false":
 			return coq.False
+		case "close":
+			return coq.GallinaIdent("Channel__Close")
+
 		}
 		ctx.unsupported(e, "special identifier")
 	}
@@ -1584,6 +1623,9 @@ func (ctx Ctx) rangeStmt(s *ast.RangeStmt) coq.Expr {
 		return ctx.mapRangeStmt(s)
 	case *types.Slice:
 		return ctx.sliceRangeStmt(s)
+	case *types.Chan:
+		ctx.todo(s, "implement channel range for loop")
+		return nil
 	default:
 		ctx.unsupported(s,
 			"range over %v (only maps and slices are supported)",
@@ -1863,6 +1905,10 @@ func (ctx Ctx) assignStmt(s *ast.AssignStmt) coq.Binding {
 	return ctx.assignFromTo(s, lhs, rhs)
 }
 
+func (ctx Ctx) sendStmt(s *ast.SendStmt) coq.Expr {
+	return coq.NewCallExpr(coq.GallinaIdent("Channel__Send"), ctx.coqTypeOfType(s.Value, ctx.typeOf(s.Value)), ctx.expr(s.Chan), ctx.expr(s.Value))
+}
+
 func (ctx Ctx) incDecStmt(stmt *ast.IncDecStmt) coq.Binding {
 	ident := getIdentOrNil(stmt.X)
 	if ident == nil {
@@ -1968,7 +2014,9 @@ func (ctx Ctx) stmtInBlock(s ast.Stmt, usage ExprValUsage) (coq.Binding, bool) {
 	case *ast.TypeSwitchStmt:
 		ctx.todo(s, "check for type switch statement")
 	case *ast.SelectStmt:
-		ctx.unsupported(s, "select statement")
+		ctx.todo(s, "add support for select statement")
+	case *ast.SendStmt:
+		binding = coq.NewAnon(ctx.sendStmt(s))
 	default:
 		ctx.unsupported(s, "statement")
 	}

--- a/internal/examples/unittest/channel.go
+++ b/internal/examples/unittest/channel.go
@@ -6,7 +6,7 @@ func chan_stuff(c chan uint64, d chan uint64) <-chan uint64 {
 	return d
 }
 
-func main() {
+func more_chan_stuff() {
 	c := make(chan uint64)
 	d := make(chan uint64)
 	c <- 1

--- a/internal/examples/unittest/channel.go
+++ b/internal/examples/unittest/channel.go
@@ -1,0 +1,21 @@
+package unittest
+
+func chan_stuff(c chan uint64, d chan uint64) <-chan uint64 {
+	var to_send uint64 = 0
+	c <- to_send
+	return d
+}
+
+func main() {
+	c := make(chan uint64)
+	d := make(chan uint64)
+	c <- 1
+	close(d)
+	var u uint64 = <-c
+	var v uint64
+	var ok bool
+	v, ok = <-d
+	ok = !ok
+	u++
+	v++
+}

--- a/internal/examples/unittest/unittest.gold.v
+++ b/internal/examples/unittest/unittest.gold.v
@@ -5,6 +5,31 @@ From Goose Require github_com.tchajed.marshal.
 
 From Perennial.goose_lang Require Import ffi.disk_prelude.
 
+(* channel.go *)
+
+Definition chan_stuff: val :=
+  rec: "chan_stuff" "c" "d" :=
+    let: "to_send" := ref_to uint64T #0 in
+    Channel__Send uint64T "c" (![uint64T] "to_send");;
+    "d".
+
+Definition main: val :=
+  rec: "main" <> :=
+    let: "c" := NewChannelRef uint64T #0 in
+    let: "d" := NewChannelRef uint64T #0 in
+    Channel__Send uint64T "c" #1;;
+    Channel__Close uint64T "d";;
+    let: "u" := ref_to uint64T (Channel__ReceiveDiscardOk uint64T "c") in
+    let: "v" := ref (zero_val uint64T) in
+    let: "ok" := ref (zero_val boolT) in
+    let: ("0_ret", "1_ret") := Channel__Receive uint64T "d" in
+    "v" <-[uint64T] "0_ret";;
+    "ok" <-[boolT] "1_ret";;
+    "ok" <-[boolT] (~ (![boolT] "ok"));;
+    "u" <-[uint64T] ((![uint64T] "u") + #1);;
+    "v" <-[uint64T] ((![uint64T] "v") + #1);;
+    #().
+
 (* comments.go *)
 
 (* unittest is a package full of many independent and small translation examples *)

--- a/internal/examples/unittest/unittest.gold.v
+++ b/internal/examples/unittest/unittest.gold.v
@@ -13,8 +13,8 @@ Definition chan_stuff: val :=
     Channel__Send uint64T "c" (![uint64T] "to_send");;
     "d".
 
-Definition main: val :=
-  rec: "main" <> :=
+Definition more_chan_stuff: val :=
+  rec: "more_chan_stuff" <> :=
     let: "c" := NewChannelRef uint64T #0 in
     let: "d" := NewChannelRef uint64T #0 in
     Channel__Send uint64T "c" #1;;

--- a/types.go
+++ b/types.go
@@ -120,6 +120,12 @@ func (ctx Ctx) coqTypeOfType(n ast.Node, t types.Type) coq.Type {
 		ctx.unsupported(n, "function type")
 	case *types.Interface:
 		return coq.InterfaceDecl{Name: ""}
+	case *types.Chan:
+		chan_coq_type := ctx.coqTypeOfType(n, t.Elem())
+		return coq.StructType{Name: "Channel", TypeParams: []coq.Type{chan_coq_type}}
+	case *types.Tuple:
+		ctx.nope(n, "tuples not handled here")
+		return nil
 	}
 	ctx.nope(n, "unknown type %v (of Go type %T)", t, t)
 	return nil // unreachable
@@ -204,7 +210,10 @@ func (ctx Ctx) coqType(e ast.Expr) coq.Type {
 	case *ast.IndexListExpr:
 		// Type parameter list for generic struct
 		return ctx.coqTypeOfType(e, ctx.typeOf(e))
-
+	case *ast.ChanType:
+		// Channels are represented as a generic struct in Goose.
+		chan_coq_type := ctx.coqType(e.Value)
+		return coq.StructType{Name: "Channel", TypeParams: []coq.Type{chan_coq_type}}
 	default:
 		ctx.unsupported(e, "unexpected type expr")
 	}


### PR DESCRIPTION
This adds support to the translator for channels by converting channel code directly to the translated channel model. I still need to add range for loops, select statements and the import statement for the channel model but this should give basic support. 

This requires https://github.com/mit-pdos/perennial/pull/185 for translated Gooselang code to compile.