### PR TITLE
Update channel model to use enum state and fix liveness issue

### DIFF
--- a/channel/README.md
+++ b/channel/README.md
@@ -19,13 +19,13 @@ stateDiagram-v2
     receiver_ready-->sender_done: Sender completes exchange
     receiver_done-->Start: Sender observes completed exchange
     sender_done-->Start: Receiver observes completed exchange
-    Start-->closed
-    receiver_done-->closed_and_receiver_done: Close before exchange acknowledged
-    sender_done-->closed_and_sender_done: Close before exchange acknowledged
-    receiver_ready-->closed
-    sender_ready-->closed
-    closed_and_receiver_done --> closed: Sender observes completed exchange
-    closed_and_sender_done --> closed: Receiver observes completed exchange
-    closed-->[*]
+    Start-->closed_final
+    receiver_done-->closed_receiver_done: Close before exchange acknowledged
+    sender_done-->closed_sender_done: Close before exchange acknowledged
+    receiver_ready-->closed_final
+    sender_ready-->closed_final
+    closed_receiver_done --> closed_final: Sender observes completed exchange
+    closed_sender_done --> closed_final: Receiver observes completed exchange
+    closed_final-->[*]
 ```
 

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -451,14 +451,9 @@ func TestNonblockSelectRace2(t *testing.T) {
 	}
 }
 
-// This tests a case where real Go channels currently have different behavior from the model,
-// so the test does not pass for the model. The case is where there are 2 separate Goroutines
-// executing select statements with a send and receive case, all on the same unbuffered
-// channel. These statements should "match" and eventually this code should make progress but
-// this will likely be a challenge to handle in a way that is semantically equivalent to Go
-// channels.
-// FIXME: Uncomment once we have support for this
-/*func TestSelfSelect(t *testing.T) {
+// Make sure that we can handle blocking select statements with matching send/receive
+// operations.
+func TestSelfSelect(t *testing.T) {
 	// Ensure that send/recv on the same chan in select
 	// does not crash nor deadlock.
 	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(2))
@@ -509,4 +504,4 @@ func TestNonblockSelectRace2(t *testing.T) {
 		}
 		wg.Wait()
 	}
-} */
+}


### PR DESCRIPTION
This now uses an enum to represent the state machine for unbuffered channels instead of a series of bools that communicated the same thing. 

State diagram:

```mermaid
stateDiagram-v2
	[*] --> Start: Create Channel
    Start-->sender_ready: Sender arrives first
    Start-->receiver_ready: Receiver arrives first
    sender_ready-->receiver_done: Receiver completes exchange
    receiver_ready-->sender_done: Sender completes exchange
    receiver_done-->Start: Sender observes completed exchange
    sender_done-->Start: Receiver observes completed exchange
    Start-->closed_final
    receiver_done-->closed_receiver_done: Close before exchange acknowledged
    sender_done-->closed_sender_done: Close before exchange acknowledged
    receiver_ready-->closed_final
    sender_ready-->closed_final
    closed_receiver_done --> closed_final: Sender observes completed exchange
    closed_sender_done --> closed_final: Receiver observes completed exchange
    closed_final-->[*]
```

For the liveness issue, I realized that it was easy enough to fix this by having goroutines attempting to send or receive in a select statement make an "offer" if there is not a waiting sender/receiver. This means that a sender will set sender_ready and a receiver will set receiver_ready, unlock and then lock immediately and check to see if the other party completed the exchange. This is a naive way to solve the problem from a performance perspective but it passes TestSelfSelect and models Go accurately in terms of correctness. 