### PR TITLE
Remove closed_sender_done and closed_receiver_done states 

### DIFF
--- a/channel/README.md
+++ b/channel/README.md
@@ -12,20 +12,16 @@ The unbuffered channel behavior in this model is described in the diagram below:
 
 ```mermaid
 stateDiagram-v2
-	[*] --> Start: Create Channel
-    Start-->sender_ready: Sender arrives first
-    Start-->receiver_ready: Receiver arrives first
+	[*] --> start: Create Channel
+    start-->sender_ready: Sender arrives first
+    start-->receiver_ready: Receiver arrives first
     sender_ready-->receiver_done: Receiver completes exchange
     receiver_ready-->sender_done: Sender completes exchange
-    receiver_done-->Start: Sender observes completed exchange
-    sender_done-->Start: Receiver observes completed exchange
-    Start-->closed_final
-    receiver_done-->closed_receiver_done: Close before exchange acknowledged
-    sender_done-->closed_sender_done: Close before exchange acknowledged
-    receiver_ready-->closed_final
-    sender_ready-->closed_final
-    closed_receiver_done --> closed_final: Sender observes completed exchange
-    closed_sender_done --> closed_final: Receiver observes completed exchange
-    closed_final-->[*]
+    receiver_done-->start: Sender observes completed exchange
+    sender_done-->start: Receiver observes completed exchange
+    start-->closed
+    receiver_ready-->closed
+    sender_ready-->closed
+    closed-->[*]
 ```
 


### PR DESCRIPTION
These states don't actually seem to be necessary 
In the runtime code, the receiver will notify the sender that the exchange is complete and copy the value while still holding the lock:
![image](https://github.com/user-attachments/assets/159589f8-e161-4bec-bdd2-79a90bf8af63)
![image](https://github.com/user-attachments/assets/2af66e1b-67a4-45a4-806a-4636fea0a11d)
This will make the code and proofs significantly simpler. 