### PR TITLE
Add explicit select support to channel model for 2 and 3 case 

### DIFF
--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -303,16 +303,17 @@ func doRequest(useSelect bool) (*response, error) {
 
 	if useSelect {
 		go func() {
-			for {
-				selected := ch.TrySend(&async{resp: nil, err: myError{}})
-				if selected {
-					break
-				} else {
-					selected, _, _ := done.TryReceive()
-					if selected {
-						break
-					}
-				}
+			case_1 := channel.NewSendCase(ch, &async{resp: nil, err: myError{}})
+			var ok bool
+			var landing struct{}
+			case_2 := channel.NewRecvCase(done, &landing, &ok)
+			selected_case := channel.TwoCaseSelect(&case_1, &case_2)
+			// These cases don't actually do anything but wanted to stick with the intended
+			// translation throughout this file.
+			if selected_case == 0 {
+
+			} else if selected_case == 1 {
+
 			}
 		}()
 	} else {
@@ -393,17 +394,22 @@ func TestNonblockSelectRace(t *testing.T) {
 		c2 := channel.NewChannelRef[int](1)
 		c1.Send(1)
 		go func() {
-			selected, _, _ := c1.TryReceive()
-			if selected {
+			var v1 int
+			var ok1 bool
+			case_1 := channel.NewRecvCase(c1, &v1, &ok1)
+			var v2 int
+			var ok2 bool
+			case_2 := channel.NewRecvCase(c2, &v2, &ok2)
+			case_3 := channel.NewDefaultCase()
+			selected_case := channel.ThreeCaseSelect(&case_1, &case_2, &case_3)
+			if selected_case == 0 {
+			}
+			if selected_case == 1 {
 
-			} else {
-				selected, _, _ = c2.TryReceive()
-				if selected {
-
-				} else {
-					done.Send(false)
-					return
-				}
+			}
+			if selected_case == 2 {
+				done.Send(false)
+				return
 			}
 			done.Send(true)
 		}()
@@ -428,17 +434,22 @@ func TestNonblockSelectRace2(t *testing.T) {
 		c2 := channel.NewChannelRef[int](1)
 		c1.Send(1)
 		go func() {
-			selected, _, _ := c1.TryReceive()
-			if selected {
+			var v1 int
+			var ok1 bool
+			case_1 := channel.NewRecvCase(c1, &v1, &ok1)
+			var v2 int
+			var ok2 bool
+			case_2 := channel.NewRecvCase(c2, &v2, &ok2)
+			case_3 := channel.NewDefaultCase()
+			selected_case := channel.ThreeCaseSelect(&case_1, &case_2, &case_3)
+			if selected_case == 0 {
+			}
+			if selected_case == 1 {
 
-			} else {
-				selected, _, _ = c2.TryReceive()
-				if selected {
-
-				} else {
-					done.Send(false)
-					return
-				}
+			}
+			if selected_case == 2 {
+				done.Send(false)
+				return
 			}
 			done.Send(true)
 		}()
@@ -467,36 +478,34 @@ func TestSelfSelect(t *testing.T) {
 				defer wg.Done()
 				for i := uint64(0); i < 1000; i++ {
 					if p == 0 || i%2 == 0 {
-						for {
-							selected := c.TrySend(p)
-							if selected {
-								break
-							} else {
-								selected, v, _ := c.TryReceive()
-								if selected {
-									if chanCap == 0 && v == p {
-										t.Errorf("self receive")
-										return
-									}
-									break
-								}
+						case_1 := channel.NewSendCase(c, p)
+						var ok bool
+						var v uint64
+						case_2 := channel.NewRecvCase(c, &v, &ok)
+						selected_case := channel.TwoCaseSelect(&case_1, &case_2)
+						if selected_case == 0 {
+							break
+						} else if selected_case == 1 {
+							if chanCap == 0 && v == p {
+								t.Errorf("self receive")
+								return
 							}
+							break
 						}
 					} else {
-						for {
-							selected, v, _ := c.TryReceive()
-							if selected {
-								if chanCap == 0 && v == p {
-									t.Errorf("self receive")
-									return
-								}
-								break
-							} else {
-								selected := c.TrySend(p)
-								if selected {
-									break
-								}
+						var ok bool
+						var v uint64
+						case_1 := channel.NewRecvCase(c, &v, &ok)
+						case_2 := channel.NewSendCase(c, p)
+						selected_case := channel.TwoCaseSelect(&case_1, &case_2)
+						if selected_case == 0 {
+							if chanCap == 0 && v == p {
+								t.Errorf("self receive")
+								return
 							}
+							break
+						} else if selected_case == 1 {
+							break
 						}
 					}
 				}
@@ -504,4 +513,103 @@ func TestSelfSelect(t *testing.T) {
 		}
 		wg.Wait()
 	}
+}
+
+// Make sure that a "perpetually selectable" closed receive case appearing first does not mean
+// it will be selected every time.
+func TestSelectLivenessOrder1(t *testing.T) {
+	c1 := channel.NewChannelRef[uint64](uint64(0))
+	c2 := channel.NewChannelRef[uint64](uint64(2))
+	c1.Close()
+	c2.Send(0)
+
+	var ok1 bool
+	var landing1 uint64
+	case_1 := channel.NewRecvCase(c1, &landing1, &ok1)
+	var ok2 bool
+	var landing2 uint64
+	case_2 := channel.NewRecvCase(c2, &landing2, &ok2)
+
+	c1_selected := false
+	c2_selected := false
+	for {
+		selected_case := channel.TwoCaseSelect(&case_1, &case_2)
+		// Make sure we eventually hit the second case
+		if selected_case == 0 {
+			c1_selected = true
+		} else if selected_case == 1 {
+			c2_selected = true
+		}
+		if c1_selected && c2_selected {
+			break
+		}
+
+	}
+
+}
+
+// Same as above but swap the case order to make sure it works symmetrically i.e. the
+// implementation doesn't have the same problem in the opposite order.
+func TestSelectLivenessOrder2(t *testing.T) {
+	c1 := channel.NewChannelRef[uint64](uint64(0))
+	c2 := channel.NewChannelRef[uint64](uint64(1))
+	var ok1 bool
+	var landing1 uint64
+	case_1 := channel.NewRecvCase(c1, &landing1, &ok1)
+	var ok2 bool
+	var landing2 uint64
+	case_2 := channel.NewRecvCase(c2, &landing2, &ok2)
+
+	c1.Close()
+	c2.Send(0)
+	c1_selected := false
+	c2_selected := false
+	for {
+		selected_case := channel.TwoCaseSelect(&case_2, &case_1)
+		// Make sure we eventually hit the second case
+		if selected_case == 0 {
+			c1_selected = true
+		} else if selected_case == 1 {
+			c2_selected = true
+		}
+		if c1_selected && c2_selected {
+			break
+		}
+
+	}
+
+}
+
+// Make sure if we keep selecting and 1 case is immediately selectable we still can choose a case
+// that eventually becomes selectable.
+func TestSelectLivenessNotImmediatelySelectable(t *testing.T) {
+	c1 := channel.NewChannelRef[uint64](uint64(0))
+	c2 := channel.NewChannelRef[uint64](uint64(0))
+	var ok1 bool
+	var landing1 uint64
+	case_1 := channel.NewRecvCase(c1, &landing1, &ok1)
+	var ok2 bool
+	var landing2 uint64
+	case_2 := channel.NewRecvCase(c2, &landing2, &ok2)
+
+	c1.Close()
+	c1_selected := false
+	c2_selected := false
+	go func() {
+		for {
+			selected_case := channel.TwoCaseSelect(&case_2, &case_1)
+			// Make sure we eventually hit the second case
+			if selected_case == 0 {
+				c1_selected = true
+			} else if selected_case == 1 {
+				c2_selected = true
+			}
+			if c1_selected && c2_selected {
+				break
+			}
+		}
+	}()
+	time.Sleep(time.Millisecond * 10)
+	c2.Send(0)
+
 }


### PR DESCRIPTION
Adding some first class support for select statements similar to the reflect package dynamic select https://cs.opensource.google/go/go/+/refs/tags/go1.24.2:src/reflect/value.go;l=2791. This should solve a couple of issues with being true to the Go runtime channel implementation when a receive case channel is verifiably closed/buffered when a select statement is reached. It also provides a fairly intuitive translation as described in the comments that will prevent having to wrap the case bodies in functions and reason about their triples. 

I am adding 2 and 3 case variants for now since that is what I need for the verification of https://go.dev/blog/pipelines and to run the existing unit tests. This should make it easy to prove the specifications. I will probably add slightly larger hardcoded variants up to maybe 5 cases later and anything larger than that would be implemented and verified as needed by existing code. Supporting variadic numbers of cases using induction would be quite annoying given that the type parameters are passed in here in the Go program and since select statements(not the dynamic version from the reflect library) need to be typed out by the programmer, I can't imagine a well-intentioned Go program using a very large number of cases. 

One detail about this that is a bit strange is that it generates a random order to attempt the case channel operations by sending goroutines on a race to append their index to a list that represents a random permutation. This wouldn't make much sense to do in real code but should be random enough for this purpose. 
The whole sequence will be:
1. Wrap the cases into a struct that holds the channel, direction, a value pointer to obtain the value for sends and land the received value for receives, and a pointer to the ok bool that will land the closed bool that returns from a receive
2. Generate a random order to attempt the non-default case channel operations
3. In that order, do TryReceive/TrySend as applicable for each case. If a case succeeds, select it, return the index for where it appears in the select statement and return ok/value for receives by reference. 
4. If none were selected and there is a default case, select the default case by returning the last index
5. Run the body of the selected case using if selected_case == 1 {case 1 body} if selected_case == 2 {case 2 body}...
Only steps 1 and 5 need to be translated for a program that uses select and step 5 can probably use pattern matching since only 1 case will be selected

As for specifications, the general idea will be:
{Pcase_1 * Pcase_2 * ...}
ThreeCaseSelect .....
{
lambda selected. 
match selected with 
   1 => Qcase_1 * Pcase_2 *....
   2 => Qcase_2 * Pcase_1 *....
   ....
   _ => False
}
At that point the user would select on the case's indices and reason about the case bodies similar to if/switch statement bodies

I updated existing unit tests with the intended translation(with the exception of single case selects, those can keep the old intended translation) and added some new ones to test the intended behavior. 

