### PR TITLE
Fix bugs preventing pav from translating

### DIFF
--- a/glang/coq.go
+++ b/glang/coq.go
@@ -402,8 +402,17 @@ func (b LetExpr) Coq(needs_paren bool) string {
 			binder(b.Names[3]),
 			binder(b.Names[4]),
 			b.ValExpr.Coq(true))
+	} else if len(b.Names) == 6 {
+		pp.Add("let: (((((%s, %s), %s), %s), %s), %s) := %s in",
+			binder(b.Names[0]),
+			binder(b.Names[1]),
+			binder(b.Names[2]),
+			binder(b.Names[3]),
+			binder(b.Names[4]),
+			binder(b.Names[5]),
+			b.ValExpr.Coq(true))
 	} else {
-		panic(fmt.Sprintf("no support for destructuring more than %d return values (up to 5 supported)", len(b.Names)))
+		panic(fmt.Sprintf("no support for destructuring more than %d return values (up to 6 supported)", len(b.Names)))
 	}
 	pp.Add("%s", b.Cont.Coq(false))
 	return addParens(needs_paren, pp.Build())

--- a/ops.go
+++ b/ops.go
@@ -1,13 +1,19 @@
 package goose
 
 import (
-	"github.com/goose-lang/goose/glang"
 	"go/token"
+
+	"github.com/goose-lang/goose/glang"
 )
 
 var generalOps = map[token.Token]glang.BinOp{
 	token.EQL: glang.OpEquals,
 	token.NEQ: glang.OpNotEquals,
+}
+
+var shiftOps = map[token.Token]struct{}{
+	token.SHL: {},
+	token.SHR: {},
 }
 
 var untypedIntOps = map[token.Token]glang.BinOp{


### PR DESCRIPTION
- Support destructing 6 return values
- Handle converting integer types in shifts
- Axiomatize methods using their correct method name (`Foo__Bar` rather than just `Bar`).