### PR TITLE
Use pkg.pkg in func_call

### DIFF
--- a/goose.go
+++ b/goose.go
@@ -877,12 +877,14 @@ func (ctx *Ctx) selectorExpr(e *ast.SelectorExpr) glang.Expr {
 			ctx.nope(e, "global variable from external package should be handled by exprAddr")
 			// return glang.IdentExpr(fmt.Sprintf("global:%s", e.Sel.Name))
 		} else if f, ok := ctx.info.ObjectOf(e.Sel).(*types.Func); ok {
+			pkgName := f.Pkg().Name()
+			pkgIdent := fmt.Sprintf("%s.%s", pkgName, pkgName)
 			return ctx.handleImplicitConversion(e,
 				ctx.info.TypeOf(e.Sel),
 				ctx.info.TypeOf(e),
 				glang.NewCallExpr(
 					glang.GallinaIdent("func_call"),
-					glang.StringVal{Value: glang.GallinaIdent(f.Pkg().Name())},
+					glang.StringVal{Value: glang.GallinaIdent(pkgIdent)},
 					glang.StringVal{Value: glang.StringLiteral{Value: e.Sel.Name}},
 				),
 			)

--- a/testdata/examples/append_log/append_log.gold.v
+++ b/testdata/examples/append_log/append_log.gold.v
@@ -23,7 +23,7 @@ Definition Log__mkHdr : val :=
     exception_do (let: "log" := (mem.alloc "log") in
     let: "enc" := (mem.alloc (type.zero_val #marshal.Enc)) in
     let: "$r0" := (let: "$a0" := disk.BlockSize in
-    (func_call #marshal #"NewEnc"%go) "$a0") in
+    (func_call #marshal.marshal #"NewEnc"%go) "$a0") in
     do:  ("enc" <-[#marshal.Enc] "$r0");;;
     do:  (let: "$a0" := (![#uint64T] (struct.field_ref #Log #"sz"%go (![#ptrT] "log"))) in
     (method_call #marshal #"Enc" #"PutInt" (![#marshal.Enc] "enc")) "$a0");;;
@@ -37,7 +37,7 @@ Definition Log__writeHdr : val :=
     exception_do (let: "log" := (mem.alloc "log") in
     do:  (let: "$a0" := #(W64 0) in
     let: "$a1" := ((method_call #append_log.append_log #"Log'ptr" #"mkHdr" (![#ptrT] "log")) #()) in
-    (func_call #disk #"Write"%go) "$a0" "$a1")).
+    (func_call #disk.disk #"Write"%go) "$a0" "$a1")).
 
 (* go: append_log.go:33:6 *)
 Definition Init : val :=
@@ -72,11 +72,11 @@ Definition Open : val :=
   rec: "Open" <> :=
     exception_do (let: "hdr" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
-    (func_call #disk #"Read"%go) "$a0") in
+    (func_call #disk.disk #"Read"%go) "$a0") in
     do:  ("hdr" <-[#sliceT] "$r0");;;
     let: "dec" := (mem.alloc (type.zero_val #marshal.Dec)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "hdr") in
-    (func_call #marshal #"NewDec"%go) "$a0") in
+    (func_call #marshal.marshal #"NewDec"%go) "$a0") in
     do:  ("dec" <-[#marshal.Dec] "$r0");;;
     let: "sz" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := ((method_call #marshal #"Dec" #"GetInt" (![#marshal.Dec] "dec")) #()) in
@@ -104,7 +104,7 @@ Definition Log__get : val :=
     (if: (![#uint64T] "i") < (![#uint64T] "sz")
     then
       return: (let: "$a0" := (#(W64 1) + (![#uint64T] "i")) in
-       (func_call #disk #"Read"%go) "$a0", #true)
+       (func_call #disk.disk #"Read"%go) "$a0", #true)
     else do:  #());;;
     return: (#slice.nil, #false)).
 
@@ -138,7 +138,7 @@ Definition writeAll : val :=
       do:  ("i" <-[#intT] "$key");;;
       do:  (let: "$a0" := ((![#uint64T] "off") + (s_to_w64 (![#intT] "i"))) in
       let: "$a1" := (![#sliceT] "bk") in
-      (func_call #disk #"Write"%go) "$a0" "$a1")))).
+      (func_call #disk.disk #"Write"%go) "$a0" "$a1")))).
 
 (* go: append_log.go:71:17 *)
 Definition Log__append : val :=

--- a/testdata/examples/logging2/logging2.gold.v
+++ b/testdata/examples/logging2/logging2.gold.v
@@ -39,10 +39,10 @@ Definition Log__writeHdr : val :=
     do:  ("hdr" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := (![#sliceT] "hdr") in
     let: "$a1" := (![#uint64T] "len") in
-    (func_call #primitive #"UInt64Put"%go) "$a0" "$a1");;;
+    (func_call #primitive.primitive #"UInt64Put"%go) "$a0" "$a1");;;
     do:  (let: "$a0" := LOGCOMMIT in
     let: "$a1" := (![#sliceT] "hdr") in
-    (func_call #disk #"Write"%go) "$a0" "$a1")).
+    (func_call #disk.disk #"Write"%go) "$a0" "$a1")).
 
 (* go: logging2.go:31:6 *)
 Definition Init : val :=
@@ -76,11 +76,11 @@ Definition Log__readHdr : val :=
     exception_do (let: "log" := (mem.alloc "log") in
     let: "hdr" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := LOGCOMMIT in
-    (func_call #disk #"Read"%go) "$a0") in
+    (func_call #disk.disk #"Read"%go) "$a0") in
     do:  ("hdr" <-[#sliceT] "$r0");;;
     let: "disklen" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "hdr") in
-    (func_call #primitive #"UInt64Get"%go) "$a0") in
+    (func_call #primitive.primitive #"UInt64Get"%go) "$a0") in
     do:  ("disklen" <-[#uint64T] "$r0");;;
     return: (![#uint64T] "disklen")).
 
@@ -98,7 +98,7 @@ Definition Log__readBlocks : val :=
     (for: (λ: <>, (![#uint64T] "i") < (![#uint64T] "len")); (λ: <>, do:  ("i" <-[#uint64T] ((![#uint64T] "i") + #(W64 1)))) := λ: <>,
       let: "blk" := (mem.alloc (type.zero_val #sliceT)) in
       let: "$r0" := (let: "$a0" := (LOGSTART + (![#uint64T] "i")) in
-      (func_call #disk #"Read"%go) "$a0") in
+      (func_call #disk.disk #"Read"%go) "$a0") in
       do:  ("blk" <-[#sliceT] "$r0");;;
       let: "$r0" := (let: "$a0" := (![#sliceT] "blks") in
       let: "$a1" := ((let: "$sl0" := (![#sliceT] "blk") in
@@ -233,7 +233,7 @@ Definition Log__writeBlocks : val :=
       do:  ("bk" <-[#sliceT] "$r0");;;
       do:  (let: "$a0" := ((![#uint64T] "pos") + (![#uint64T] "i")) in
       let: "$a1" := (![#sliceT] "bk") in
-      (func_call #disk #"Write"%go) "$a0" "$a1")))).
+      (func_call #disk.disk #"Write"%go) "$a0" "$a1")))).
 
 (* go: logging2.go:123:16 *)
 Definition Log__diskAppend : val :=
@@ -343,7 +343,7 @@ Definition Txn__Read : val :=
     then return: (![#sliceT] "v")
     else
       return: (let: "$a0" := ((![#uint64T] "addr") + LOGEND) in
-       (func_call #disk #"Read"%go) "$a0"))).
+       (func_call #disk.disk #"Read"%go) "$a0"))).
 
 (* go: txn.go:47:16 *)
 Definition Txn__Commit : val :=

--- a/testdata/examples/semantics/semantics.gold.v
+++ b/testdata/examples/semantics/semantics.gold.v
@@ -501,10 +501,10 @@ Definition roundtripEncDec32 : val :=
     do:  (let: "$a0" := (let: "$a0" := #(W64 4) in
     (method_call #semantics.semantics #"Enc'ptr" #"consume" (![#ptrT] "e")) "$a0") in
     let: "$a1" := (![#uint32T] "x") in
-    (func_call #primitive #"UInt32Put"%go) "$a0" "$a1");;;
+    (func_call #primitive.primitive #"UInt32Put"%go) "$a0" "$a1");;;
     return: (let: "$a0" := (let: "$a0" := #(W64 4) in
      (method_call #semantics.semantics #"Dec'ptr" #"consume" (![#ptrT] "d")) "$a0") in
-     (func_call #primitive #"UInt32Get"%go) "$a0")).
+     (func_call #primitive.primitive #"UInt32Get"%go) "$a0")).
 
 (* go: encoding.go:34:6 *)
 Definition roundtripEncDec64 : val :=
@@ -528,10 +528,10 @@ Definition roundtripEncDec64 : val :=
     do:  (let: "$a0" := (let: "$a0" := #(W64 8) in
     (method_call #semantics.semantics #"Enc'ptr" #"consume" (![#ptrT] "e")) "$a0") in
     let: "$a1" := (![#uint64T] "x") in
-    (func_call #primitive #"UInt64Put"%go) "$a0" "$a1");;;
+    (func_call #primitive.primitive #"UInt64Put"%go) "$a0" "$a1");;;
     return: (let: "$a0" := (let: "$a0" := #(W64 8) in
      (method_call #semantics.semantics #"Dec'ptr" #"consume" (![#ptrT] "d")) "$a0") in
-     (func_call #primitive #"UInt64Get"%go) "$a0")).
+     (func_call #primitive.primitive #"UInt64Get"%go) "$a0")).
 
 (* tests
 
@@ -1761,7 +1761,7 @@ Definition testLinearize : val :=
     let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("m" <-[#ptrT] "$r0");;;
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] "m")) #());;;
-    do:  ((func_call #primitive #"Linearize"%go) #());;;
+    do:  ((func_call #primitive.primitive #"Linearize"%go) #());;;
     do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] "m")) #());;;
     return: (#true)).
 
@@ -2534,7 +2534,7 @@ Definition intToBlock : val :=
     do:  ("b" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := (![#sliceT] "b") in
     let: "$a1" := (![#uint64T] "a") in
-    (func_call #primitive #"UInt64Put"%go) "$a0" "$a1");;;
+    (func_call #primitive.primitive #"UInt64Put"%go) "$a0" "$a1");;;
     return: (![#sliceT] "b")).
 
 (* go: wal.go:31:6 *)
@@ -2543,7 +2543,7 @@ Definition blockToInt : val :=
     exception_do (let: "v" := (mem.alloc "v") in
     let: "a" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "v") in
-    (func_call #primitive #"UInt64Get"%go) "$a0") in
+    (func_call #primitive.primitive #"UInt64Get"%go) "$a0") in
     do:  ("a" <-[#uint64T] "$r0");;;
     return: (![#uint64T] "a")).
 
@@ -2553,7 +2553,7 @@ Definition blockToInt : val :=
 Definition New : val :=
   rec: "New" <> :=
     exception_do (let: "d" := (mem.alloc (type.zero_val #disk.Disk)) in
-    let: "$r0" := ((func_call #disk #"Get"%go) #()) in
+    let: "$r0" := ((func_call #disk.disk #"Get"%go) #()) in
     do:  ("d" <-[#disk.Disk] "$r0");;;
     let: "diskSize" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := ((interface.get #"Size"%go (![#disk.Disk] "d")) #()) in
@@ -2809,7 +2809,7 @@ Definition Log__Apply : val :=
 Definition Open : val :=
   rec: "Open" <> :=
     exception_do (let: "d" := (mem.alloc (type.zero_val #disk.Disk)) in
-    let: "$r0" := ((func_call #disk #"Get"%go) #()) in
+    let: "$r0" := ((func_call #disk.disk #"Get"%go) #()) in
     do:  ("d" <-[#disk.Disk] "$r0");;;
     let: "header" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in

--- a/testdata/examples/simpledb/simpledb.gold.v
+++ b/testdata/examples/simpledb/simpledb.gold.v
@@ -16,7 +16,7 @@ Context `{ffi_syntax}.
 Definition UseMarshal : val :=
   rec: "UseMarshal" <> :=
     exception_do (do:  (let: "$a0" := #(W64 0) in
-    (func_call #marshal #"NewEnc"%go) "$a0")).
+    (func_call #marshal.marshal #"NewEnc"%go) "$a0")).
 
 Definition Table : go_type := structT [
   "Index" :: mapT uint64T uint64T;
@@ -35,17 +35,17 @@ Definition CreateTable : val :=
     let: "f" := (mem.alloc (type.zero_val #fileT)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := #"db"%go in
     let: "$a1" := (![#stringT] "p") in
-    (func_call #filesys #"Create"%go) "$a0" "$a1") in
+    (func_call #filesys.filesys #"Create"%go) "$a0" "$a1") in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
     do:  ("f" <-[#fileT] "$r0");;;
     do:  "$r1";;;
     do:  (let: "$a0" := (![#fileT] "f") in
-    (func_call #filesys #"Close"%go) "$a0");;;
+    (func_call #filesys.filesys #"Close"%go) "$a0");;;
     let: "f2" := (mem.alloc (type.zero_val #fileT)) in
     let: "$r0" := (let: "$a0" := #"db"%go in
     let: "$a1" := (![#stringT] "p") in
-    (func_call #filesys #"Open"%go) "$a0" "$a1") in
+    (func_call #filesys.filesys #"Open"%go) "$a0" "$a1") in
     do:  ("f2" <-[#fileT] "$r0");;;
     return: (let: "$Index" := (![#(mapT uint64T uint64T)] "index") in
      let: "$File" := (![#fileT] "f2") in
@@ -76,7 +76,7 @@ Definition DecodeUInt64 : val :=
     else do:  #());;;
     let: "n" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "p") in
-    (func_call #primitive #"UInt64Get"%go) "$a0") in
+    (func_call #primitive.primitive #"UInt64Get"%go) "$a0") in
     do:  ("n" <-[#uint64T] "$r0");;;
     return: (![#uint64T] "n", #(W64 8))).
 
@@ -190,7 +190,7 @@ Definition readTableIndex : val :=
         let: "$a1" := ((![#uint64T] (struct.field_ref #lazyFileBuf #"offset"%go "buf")) + (s_to_w64 (let: "$a0" := (![#sliceT] (struct.field_ref #lazyFileBuf #"next"%go "buf")) in
         slice.len "$a0"))) in
         let: "$a2" := #(W64 4096) in
-        (func_call #filesys #"ReadAt"%go) "$a0" "$a1" "$a2") in
+        (func_call #filesys.filesys #"ReadAt"%go) "$a0" "$a1" "$a2") in
         do:  ("p" <-[#sliceT] "$r0");;;
         (if: (let: "$a0" := (![#sliceT] "p") in
         slice.len "$a0") = #(W64 0)
@@ -222,7 +222,7 @@ Definition RecoverTable : val :=
     let: "f" := (mem.alloc (type.zero_val #fileT)) in
     let: "$r0" := (let: "$a0" := #"db"%go in
     let: "$a1" := (![#stringT] "p") in
-    (func_call #filesys #"Open"%go) "$a0" "$a1") in
+    (func_call #filesys.filesys #"Open"%go) "$a0" "$a1") in
     do:  ("f" <-[#fileT] "$r0");;;
     do:  (let: "$a0" := (![#fileT] "f") in
     let: "$a1" := (![#(mapT uint64T uint64T)] "index") in
@@ -241,7 +241,7 @@ Definition CloseTable : val :=
   rec: "CloseTable" "t" :=
     exception_do (let: "t" := (mem.alloc "t") in
     do:  (let: "$a0" := (![#fileT] (struct.field_ref #Table #"File"%go "t")) in
-    (func_call #filesys #"Close"%go) "$a0")).
+    (func_call #filesys.filesys #"Close"%go) "$a0")).
 
 (* go: simpledb.go:123:6 *)
 Definition readValue : val :=
@@ -252,11 +252,11 @@ Definition readValue : val :=
     let: "$r0" := (let: "$a0" := (![#fileT] "f") in
     let: "$a1" := (![#uint64T] "off") in
     let: "$a2" := #(W64 512) in
-    (func_call #filesys #"ReadAt"%go) "$a0" "$a1" "$a2") in
+    (func_call #filesys.filesys #"ReadAt"%go) "$a0" "$a1" "$a2") in
     do:  ("startBuf" <-[#sliceT] "$r0");;;
     let: "totalBytes" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "startBuf") in
-    (func_call #primitive #"UInt64Get"%go) "$a0") in
+    (func_call #primitive.primitive #"UInt64Get"%go) "$a0") in
     do:  ("totalBytes" <-[#uint64T] "$r0");;;
     let: "buf" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$s" := (![#sliceT] "startBuf") in
@@ -272,7 +272,7 @@ Definition readValue : val :=
       let: "$r0" := (let: "$a0" := (![#fileT] "f") in
       let: "$a1" := ((![#uint64T] "off") + #(W64 512)) in
       let: "$a2" := ((![#uint64T] "totalBytes") - (![#uint64T] "haveBytes")) in
-      (func_call #filesys #"ReadAt"%go) "$a0" "$a1" "$a2") in
+      (func_call #filesys.filesys #"ReadAt"%go) "$a0" "$a1" "$a2") in
       do:  ("buf2" <-[#sliceT] "$r0");;;
       let: "newBuf" := (mem.alloc (type.zero_val #sliceT)) in
       let: "$r0" := (let: "$a0" := (![#sliceT] "buf") in
@@ -338,7 +338,7 @@ Definition bufFlush : val :=
     else do:  #());;;
     do:  (let: "$a0" := (![#fileT] (struct.field_ref #bufFile #"file"%go "f")) in
     let: "$a1" := (![#sliceT] "buf") in
-    (func_call #filesys #"Append"%go) "$a0" "$a1");;;
+    (func_call #filesys.filesys #"Append"%go) "$a0" "$a1");;;
     let: "$r0" := #slice.nil in
     do:  ((![#ptrT] (struct.field_ref #bufFile #"buf"%go "f")) <-[#sliceT] "$r0")).
 
@@ -365,7 +365,7 @@ Definition bufClose : val :=
     do:  (let: "$a0" := (![#bufFile] "f") in
     (func_call #simpledb.simpledb #"bufFlush"%go) "$a0");;;
     do:  (let: "$a0" := (![#fileT] (struct.field_ref #bufFile #"file"%go "f")) in
-    (func_call #filesys #"Close"%go) "$a0")).
+    (func_call #filesys.filesys #"Close"%go) "$a0")).
 
 Definition tableWriter : go_type := structT [
   "index" :: mapT uint64T uint64T;
@@ -384,7 +384,7 @@ Definition newTableWriter : val :=
     let: "f" := (mem.alloc (type.zero_val #fileT)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := #"db"%go in
     let: "$a1" := (![#stringT] "p") in
-    (func_call #filesys #"Create"%go) "$a0" "$a1") in
+    (func_call #filesys.filesys #"Create"%go) "$a0" "$a1") in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
     do:  ("f" <-[#fileT] "$r0");;;
@@ -431,7 +431,7 @@ Definition tableWriterClose : val :=
     let: "f" := (mem.alloc (type.zero_val #fileT)) in
     let: "$r0" := (let: "$a0" := #"db"%go in
     let: "$a1" := (![#stringT] (struct.field_ref #tableWriter #"name"%go "w")) in
-    (func_call #filesys #"Open"%go) "$a0" "$a1") in
+    (func_call #filesys.filesys #"Open"%go) "$a0" "$a1") in
     do:  ("f" <-[#fileT] "$r0");;;
     return: (let: "$Index" := (![#(mapT uint64T uint64T)] (struct.field_ref #tableWriter #"index"%go "w")) in
      let: "$File" := (![#fileT] "f") in
@@ -452,7 +452,7 @@ Definition EncodeUInt64 : val :=
     do:  ("tmp" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := (![#sliceT] "tmp") in
     let: "$a1" := (![#uint64T] "x") in
-    (func_call #primitive #"UInt64Put"%go) "$a0" "$a1");;;
+    (func_call #primitive.primitive #"UInt64Put"%go) "$a0" "$a1");;;
     let: "p2" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "p") in
     let: "$a1" := (![#sliceT] "tmp") in
@@ -749,7 +749,7 @@ Definition tablePutOldTable : val :=
         let: "$a1" := ((![#uint64T] (struct.field_ref #lazyFileBuf #"offset"%go "buf")) + (s_to_w64 (let: "$a0" := (![#sliceT] (struct.field_ref #lazyFileBuf #"next"%go "buf")) in
         slice.len "$a0"))) in
         let: "$a2" := #(W64 4096) in
-        (func_call #filesys #"ReadAt"%go) "$a0" "$a1" "$a2") in
+        (func_call #filesys.filesys #"ReadAt"%go) "$a0" "$a1" "$a2") in
         do:  ("p" <-[#sliceT] "$r0");;;
         (if: (let: "$a0" := (![#sliceT] "p") in
         slice.len "$a0") = #(W64 0)
@@ -857,12 +857,12 @@ Definition Compact : val :=
     do:  (let: "$a0" := #"db"%go in
     let: "$a1" := #"manifest"%go in
     let: "$a2" := (![#sliceT] "manifestData") in
-    (func_call #filesys #"AtomicCreate"%go) "$a0" "$a1" "$a2");;;
+    (func_call #filesys.filesys #"AtomicCreate"%go) "$a0" "$a1" "$a2");;;
     do:  (let: "$a0" := (![#Table] "oldTable") in
     (func_call #simpledb.simpledb #"CloseTable"%go) "$a0");;;
     do:  (let: "$a0" := #"db"%go in
     let: "$a1" := (![#stringT] "oldTableName") in
-    (func_call #filesys #"Delete"%go) "$a0" "$a1");;;
+    (func_call #filesys.filesys #"Delete"%go) "$a0" "$a1");;;
     do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Database #"tableL"%go "db"))) #());;;
     do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Database #"compactionL"%go "db"))) #())).
 
@@ -872,19 +872,19 @@ Definition recoverManifest : val :=
     exception_do (let: "f" := (mem.alloc (type.zero_val #fileT)) in
     let: "$r0" := (let: "$a0" := #"db"%go in
     let: "$a1" := #"manifest"%go in
-    (func_call #filesys #"Open"%go) "$a0" "$a1") in
+    (func_call #filesys.filesys #"Open"%go) "$a0" "$a1") in
     do:  ("f" <-[#fileT] "$r0");;;
     let: "manifestData" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#fileT] "f") in
     let: "$a1" := #(W64 0) in
     let: "$a2" := #(W64 4096) in
-    (func_call #filesys #"ReadAt"%go) "$a0" "$a1" "$a2") in
+    (func_call #filesys.filesys #"ReadAt"%go) "$a0" "$a1" "$a2") in
     do:  ("manifestData" <-[#sliceT] "$r0");;;
     let: "tableName" := (mem.alloc (type.zero_val #stringT)) in
     let: "$r0" := (string.from_bytes (![#sliceT] "manifestData")) in
     do:  ("tableName" <-[#stringT] "$r0");;;
     do:  (let: "$a0" := (![#fileT] "f") in
-    (func_call #filesys #"Close"%go) "$a0");;;
+    (func_call #filesys.filesys #"Close"%go) "$a0");;;
     return: (![#stringT] "tableName")).
 
 (* delete 'name' if it isn't tableName or "manifest"
@@ -902,7 +902,7 @@ Definition deleteOtherFile : val :=
     else do:  #());;;
     do:  (let: "$a0" := #"db"%go in
     let: "$a1" := (![#stringT] "name") in
-    (func_call #filesys #"Delete"%go) "$a0" "$a1")).
+    (func_call #filesys.filesys #"Delete"%go) "$a0" "$a1")).
 
 (* go: simpledb.go:474:6 *)
 Definition deleteOtherFiles : val :=
@@ -910,7 +910,7 @@ Definition deleteOtherFiles : val :=
     exception_do (let: "tableName" := (mem.alloc "tableName") in
     let: "files" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := #"db"%go in
-    (func_call #filesys #"List"%go) "$a0") in
+    (func_call #filesys.filesys #"List"%go) "$a0") in
     do:  ("files" <-[#sliceT] "$r0");;;
     let: "nfiles" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (s_to_w64 (let: "$a0" := (![#sliceT] "files") in

--- a/testdata/examples/unittest/unittest.gold.v
+++ b/testdata/examples/unittest/unittest.gold.v
@@ -148,7 +148,7 @@ Definition chanSelect : val :=
         let: "$sl2" := (interface.make #""%go #"string"%go #" to c2
         "%go) in
         slice.literal #interfaceT ["$sl0"; "$sl1"; "$sl2"])) in
-        (func_call #fmt #"Print"%go) "$a0")
+        (func_call #fmt.fmt #"Print"%go) "$a0")
         ))] [("$recvChan0", (λ: "$recvVal",
         do:  #()
         )); ("$recvChan1", (λ: "$recvVal",
@@ -159,7 +159,7 @@ Definition chanSelect : val :=
         let: "$sl2" := (interface.make #""%go #"string"%go #" from c1
         "%go) in
         slice.literal #interfaceT ["$sl0"; "$sl1"; "$sl2"])) in
-        (func_call #fmt #"Print"%go) "$a0")
+        (func_call #fmt.fmt #"Print"%go) "$a0")
         )); ("$recvChan2", (λ: "$recvVal",
         let: "ok" := (mem.alloc (type.zero_val #boolT)) in
         let: "i3" := (mem.alloc (type.zero_val #intT)) in
@@ -175,12 +175,12 @@ Definition chanSelect : val :=
           let: "$sl2" := (interface.make #""%go #"string"%go #" from c3
           "%go) in
           slice.literal #interfaceT ["$sl0"; "$sl1"; "$sl2"])) in
-          (func_call #fmt #"Print"%go) "$a0")
+          (func_call #fmt.fmt #"Print"%go) "$a0")
         else
           do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"c3 is closed
           "%go) in
           slice.literal #interfaceT ["$sl0"])) in
-          (func_call #fmt #"Print"%go) "$a0"))
+          (func_call #fmt.fmt #"Print"%go) "$a0"))
         )); ("$recvChan3", (λ: "$recvVal",
         let: "$r0" := (Fst "$recvVal") in
         do:  ((slice.elem_ref #intT (![#sliceT] "a") ((func_call #unittest.unittest #"f"%go) #())) <-[#intT] "$r0");;;
@@ -189,7 +189,7 @@ Definition chanSelect : val :=
       do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"no communication
       "%go) in
       slice.literal #interfaceT ["$sl0"])) in
-      (func_call #fmt #"Print"%go) "$a0")
+      (func_call #fmt.fmt #"Print"%go) "$a0")
       )));;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
       do:  (chan.select [("$sendVal0", "$sendChan0", (λ: <>,
@@ -219,14 +219,14 @@ Definition chanRange : val :=
       do:  ("y" <-[#uint64T] "$key");;;
       do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"uint64"%go (![#uint64T] "y")) in
       slice.literal #interfaceT ["$sl0"])) in
-      (func_call #fmt #"Print"%go) "$a0")));;;
+      (func_call #fmt.fmt #"Print"%go) "$a0")));;;
     let: "$range" := (![#(chanT uint64T)] "x") in
     (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     chan.for_range "$range" (λ: "$key",
       do:  ("x" <-[#uint64T] "$key");;;
       do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"uint64"%go (![#uint64T] "x")) in
       slice.literal #interfaceT ["$sl0"])) in
-      (func_call #fmt #"Print"%go) "$a0")));;;
+      (func_call #fmt.fmt #"Print"%go) "$a0")));;;
     let: "$range" := (![#(chanT uint64T)] "x") in
     chan.for_range "$range" (λ: "$key",
       do:  #())).
@@ -265,7 +265,7 @@ Definition condvarWrapping : val :=
     do:  ("mu" <-[#ptrT] "$r0");;;
     let: "cond1" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (let: "$a0" := (interface.make #sync #"Mutex'ptr" (![#ptrT] "mu")) in
-    (func_call #sync #"NewCond"%go) "$a0") in
+    (func_call #sync.sync #"NewCond"%go) "$a0") in
     do:  ("cond1" <-[#ptrT] "$r0");;;
     let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("mu" <-[#ptrT] "$r0");;;
@@ -639,7 +639,7 @@ Definition iterMapKeys : val :=
 Definition getRandom : val :=
   rec: "getRandom" <> :=
     exception_do (let: "r" := (mem.alloc (type.zero_val #uint64T)) in
-    let: "$r0" := ((func_call #primitive #"RandomUint64"%go) #()) in
+    let: "$r0" := ((func_call #primitive.primitive #"RandomUint64"%go) #()) in
     do:  ("r" <-[#uint64T] "$r0");;;
     return: (![#uint64T] "r")).
 
@@ -792,7 +792,7 @@ Definition Enc__UInt64 : val :=
     do:  (let: "$a0" := (let: "$a0" := #(W64 8) in
     (method_call #unittest.unittest #"Enc'ptr" #"consume" (![#ptrT] "e")) "$a0") in
     let: "$a1" := (![#uint64T] "x") in
-    (func_call #primitive #"UInt64Put"%go) "$a0" "$a1")).
+    (func_call #primitive.primitive #"UInt64Put"%go) "$a0" "$a1")).
 
 (* go: encoding.go:19:15 *)
 Definition Enc__UInt32 : val :=
@@ -802,7 +802,7 @@ Definition Enc__UInt32 : val :=
     do:  (let: "$a0" := (let: "$a0" := #(W64 4) in
     (method_call #unittest.unittest #"Enc'ptr" #"consume" (![#ptrT] "e")) "$a0") in
     let: "$a1" := (![#uint32T] "x") in
-    (func_call #primitive #"UInt32Put"%go) "$a0" "$a1")).
+    (func_call #primitive.primitive #"UInt32Put"%go) "$a0" "$a1")).
 
 Definition Dec : go_type := structT [
   "p" :: sliceT
@@ -828,7 +828,7 @@ Definition Dec__UInt64 : val :=
     exception_do (let: "d" := (mem.alloc "d") in
     return: (let: "$a0" := (let: "$a0" := #(W64 8) in
      (method_call #unittest.unittest #"Dec'ptr" #"consume" (![#ptrT] "d")) "$a0") in
-     (func_call #primitive #"UInt64Get"%go) "$a0")).
+     (func_call #primitive.primitive #"UInt64Get"%go) "$a0")).
 
 (* go: encoding.go:37:15 *)
 Definition Dec__UInt32 : val :=
@@ -836,7 +836,7 @@ Definition Dec__UInt32 : val :=
     exception_do (let: "d" := (mem.alloc "d") in
     return: (let: "$a0" := (let: "$a0" := #(W64 4) in
      (method_call #unittest.unittest #"Dec'ptr" #"consume" (![#ptrT] "d")) "$a0") in
-     (func_call #primitive #"UInt32Get"%go) "$a0")).
+     (func_call #primitive.primitive #"UInt32Get"%go) "$a0")).
 
 (* go: for_range.go:5:6 *)
 Definition forRangeNoBinding : val :=
@@ -846,7 +846,7 @@ Definition forRangeNoBinding : val :=
     slice.for_range #stringT "$range" (λ: "$key" "$value",
       do:  (let: "$a0" := ((let: "$sl0" := (interface.make #"slice'"%go (![#sliceT] "x")) in
       slice.literal #interfaceT ["$sl0"])) in
-      (func_call #fmt #"Print"%go) "$a0"))).
+      (func_call #fmt.fmt #"Print"%go) "$a0"))).
 
 (* go: for_range.go:11:6 *)
 Definition forRangeOldVars : val :=
@@ -861,7 +861,7 @@ Definition forRangeOldVars : val :=
       do:  "$key";;;
       do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go (![#stringT] "y")) in
       slice.literal #interfaceT ["$sl0"])) in
-      (func_call #fmt #"Print"%go) "$a0"))).
+      (func_call #fmt.fmt #"Print"%go) "$a0"))).
 
 (* go: globals.go:3:6 *)
 Definition foo : val :=
@@ -1202,7 +1202,7 @@ Definition useCondVar : val :=
     do:  ("m" <-[#ptrT] "$r0");;;
     let: "c" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (let: "$a0" := (interface.make #sync #"Mutex'ptr" (![#ptrT] "m")) in
-    (func_call #sync #"NewCond"%go) "$a0") in
+    (func_call #sync.sync #"NewCond"%go) "$a0") in
     do:  ("c" <-[#ptrT] "$r0");;;
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] "m")) #());;;
     do:  ((method_call #sync #"Cond'ptr" #"Signal" (![#ptrT] "c")) #());;;
@@ -1219,14 +1219,14 @@ Definition ToBeDebugged : val :=
     exception_do (let: "x" := (mem.alloc "x") in
     do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"starting function"%go) in
     slice.literal #interfaceT ["$sl0"])) in
-    (func_call #log #"Println"%go) "$a0");;;
+    (func_call #log.log #"Println"%go) "$a0");;;
     do:  (let: "$a0" := #"called with %d"%go in
     let: "$a1" := ((let: "$sl0" := (interface.make #""%go #"uint64"%go (![#uint64T] "x")) in
     slice.literal #interfaceT ["$sl0"])) in
-    (func_call #log #"Printf"%go) "$a0" "$a1");;;
+    (func_call #log.log #"Printf"%go) "$a0" "$a1");;;
     do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"ending function"%go) in
     slice.literal #interfaceT ["$sl0"])) in
-    (func_call #log #"Println"%go) "$a0");;;
+    (func_call #log.log #"Println"%go) "$a0");;;
     return: (![#uint64T] "x")).
 
 (* go: log_debugging.go:12:6 *)
@@ -1234,7 +1234,7 @@ Definition DoNothing : val :=
   rec: "DoNothing" <> :=
     exception_do (do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"doing nothing"%go) in
     slice.literal #interfaceT ["$sl0"])) in
-    (func_call #log #"Println"%go) "$a0")).
+    (func_call #log.log #"Println"%go) "$a0")).
 
 (* DoSomething is an impure function
 
@@ -1639,7 +1639,7 @@ Definition PanicAtTheDisco : val :=
 Definition Oracle : val :=
   rec: "Oracle" <> :=
     exception_do (let: "p" := (mem.alloc (type.zero_val #ptrT)) in
-    let: "$r0" := ((func_call #primitive #"NewProph"%go) #()) in
+    let: "$r0" := ((func_call #primitive.primitive #"NewProph"%go) #()) in
     do:  ("p" <-[#ptrT] "$r0");;;
     let: "$r0" := (![#ptrT] "p") in
     do:  ("p" <-[#ptrT] "$r0")).
@@ -1713,7 +1713,7 @@ Definition useRenamedImport : val :=
   rec: "useRenamedImport" <> :=
     exception_do (do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"blah"%go) in
     slice.literal #interfaceT ["$sl0"])) in
-    (func_call #fmt #"Print"%go) "$a0")).
+    (func_call #fmt.fmt #"Print"%go) "$a0")).
 
 Definition Block : go_type := structT [
   "Value" :: uint64T
@@ -2186,7 +2186,7 @@ Definition makeLock : val :=
 Definition sleep : val :=
   rec: "sleep" <> :=
     exception_do (do:  (let: "$a0" := #(W64 1000) in
-    (func_call #primitive #"Sleep"%go) "$a0")).
+    (func_call #primitive.primitive #"Sleep"%go) "$a0")).
 
 Definition A : go_type := structT [
 ].

--- a/testdata/examples/wal/wal.gold.v
+++ b/testdata/examples/wal/wal.gold.v
@@ -32,7 +32,7 @@ Definition intToBlock : val :=
     do:  ("b" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := (![#sliceT] "b") in
     let: "$a1" := (![#uint64T] "a") in
-    (func_call #primitive #"UInt64Put"%go) "$a0" "$a1");;;
+    (func_call #primitive.primitive #"UInt64Put"%go) "$a0" "$a1");;;
     return: (![#sliceT] "b")).
 
 (* go: log.go:31:6 *)
@@ -41,7 +41,7 @@ Definition blockToInt : val :=
     exception_do (let: "v" := (mem.alloc "v") in
     let: "a" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "v") in
-    (func_call #primitive #"UInt64Get"%go) "$a0") in
+    (func_call #primitive.primitive #"UInt64Get"%go) "$a0") in
     do:  ("a" <-[#uint64T] "$r0");;;
     return: (![#uint64T] "a")).
 
@@ -51,7 +51,7 @@ Definition blockToInt : val :=
 Definition New : val :=
   rec: "New" <> :=
     exception_do (let: "d" := (mem.alloc (type.zero_val #disk.Disk)) in
-    let: "$r0" := ((func_call #disk #"Get"%go) #()) in
+    let: "$r0" := ((func_call #disk.disk #"Get"%go) #()) in
     do:  ("d" <-[#disk.Disk] "$r0");;;
     let: "diskSize" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := ((interface.get #"Size"%go (![#disk.Disk] "d")) #()) in
@@ -307,7 +307,7 @@ Definition Log__Apply : val :=
 Definition Open : val :=
   rec: "Open" <> :=
     exception_do (let: "d" := (mem.alloc (type.zero_val #disk.Disk)) in
-    let: "$r0" := ((func_call #disk #"Get"%go) #()) in
+    let: "$r0" := ((func_call #disk.disk #"Get"%go) #()) in
     do:  ("d" <-[#disk.Disk] "$r0");;;
     let: "header" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in


### PR DESCRIPTION
This ensures the package name is chosen over an identifier with the same name. This fixes an error I ran into where `message` refers to something from grove_ffi but `message.message` fixes it.