### PR TITLE
Use mem.alloc to refer to allocation

### DIFF
--- a/glang/coq.go
+++ b/glang/coq.go
@@ -700,7 +700,7 @@ type RefExpr struct {
 }
 
 func (e RefExpr) Coq(needs_paren bool) string {
-	return NewCallExpr(GallinaIdent("alloc"), e.X).Coq(needs_paren)
+	return NewCallExpr(GallinaIdent("mem.alloc"), e.X).Coq(needs_paren)
 }
 
 type StoreStmt struct {

--- a/testdata/examples/append_log/append_log.gold.v
+++ b/testdata/examples/append_log/append_log.gold.v
@@ -20,8 +20,8 @@ Definition Log : go_type := structT [
 (* go: append_log.go:22:17 *)
 Definition Log__mkHdr : val :=
   rec: "Log__mkHdr" "log" <> :=
-    exception_do (let: "log" := (alloc "log") in
-    let: "enc" := (alloc (type.zero_val #marshal.Enc)) in
+    exception_do (let: "log" := (mem.alloc "log") in
+    let: "enc" := (mem.alloc (type.zero_val #marshal.Enc)) in
     let: "$r0" := (let: "$a0" := disk.BlockSize in
     (func_call #marshal #"NewEnc"%go) "$a0") in
     do:  ("enc" <-[#marshal.Enc] "$r0");;;
@@ -34,7 +34,7 @@ Definition Log__mkHdr : val :=
 (* go: append_log.go:29:17 *)
 Definition Log__writeHdr : val :=
   rec: "Log__writeHdr" "log" <> :=
-    exception_do (let: "log" := (alloc "log") in
+    exception_do (let: "log" := (mem.alloc "log") in
     do:  (let: "$a0" := #(W64 0) in
     let: "$a1" := ((method_call #append_log.append_log #"Log'ptr" #"mkHdr" (![#ptrT] "log")) #()) in
     (func_call #disk #"Write"%go) "$a0" "$a1")).
@@ -42,10 +42,10 @@ Definition Log__writeHdr : val :=
 (* go: append_log.go:33:6 *)
 Definition Init : val :=
   rec: "Init" "diskSz" :=
-    exception_do (let: "diskSz" := (alloc "diskSz") in
+    exception_do (let: "diskSz" := (mem.alloc "diskSz") in
     (if: (![#uint64T] "diskSz") < #(W64 1)
     then
-      return: (alloc (let: "$m" := (alloc (type.zero_val #sync.Mutex)) in
+      return: (mem.alloc (let: "$m" := (mem.alloc (type.zero_val #sync.Mutex)) in
        let: "$sz" := #(W64 0) in
        let: "$diskSz" := #(W64 0) in
        struct.make #Log [{
@@ -54,8 +54,8 @@ Definition Init : val :=
          "diskSz" ::= "$diskSz"
        }]), #false)
     else do:  #());;;
-    let: "log" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (let: "$m" := (alloc (type.zero_val #sync.Mutex)) in
+    let: "log" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (let: "$m" := (mem.alloc (type.zero_val #sync.Mutex)) in
     let: "$sz" := #(W64 0) in
     let: "$diskSz" := (![#uint64T] "diskSz") in
     struct.make #Log [{
@@ -70,21 +70,21 @@ Definition Init : val :=
 (* go: append_log.go:42:6 *)
 Definition Open : val :=
   rec: "Open" <> :=
-    exception_do (let: "hdr" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "hdr" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
     (func_call #disk #"Read"%go) "$a0") in
     do:  ("hdr" <-[#sliceT] "$r0");;;
-    let: "dec" := (alloc (type.zero_val #marshal.Dec)) in
+    let: "dec" := (mem.alloc (type.zero_val #marshal.Dec)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "hdr") in
     (func_call #marshal #"NewDec"%go) "$a0") in
     do:  ("dec" <-[#marshal.Dec] "$r0");;;
-    let: "sz" := (alloc (type.zero_val #uint64T)) in
+    let: "sz" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := ((method_call #marshal #"Dec" #"GetInt" (![#marshal.Dec] "dec")) #()) in
     do:  ("sz" <-[#uint64T] "$r0");;;
-    let: "diskSz" := (alloc (type.zero_val #uint64T)) in
+    let: "diskSz" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := ((method_call #marshal #"Dec" #"GetInt" (![#marshal.Dec] "dec")) #()) in
     do:  ("diskSz" <-[#uint64T] "$r0");;;
-    return: (alloc (let: "$m" := (alloc (type.zero_val #sync.Mutex)) in
+    return: (mem.alloc (let: "$m" := (mem.alloc (type.zero_val #sync.Mutex)) in
      let: "$sz" := (![#uint64T] "sz") in
      let: "$diskSz" := (![#uint64T] "diskSz") in
      struct.make #Log [{
@@ -96,9 +96,9 @@ Definition Open : val :=
 (* go: append_log.go:50:17 *)
 Definition Log__get : val :=
   rec: "Log__get" "log" "i" :=
-    exception_do (let: "log" := (alloc "log") in
-    let: "i" := (alloc "i") in
-    let: "sz" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "log" := (mem.alloc "log") in
+    let: "i" := (mem.alloc "i") in
+    let: "sz" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (struct.field_ref #Log #"sz"%go (![#ptrT] "log"))) in
     do:  ("sz" <-[#uint64T] "$r0");;;
     (if: (![#uint64T] "i") < (![#uint64T] "sz")
@@ -111,11 +111,11 @@ Definition Log__get : val :=
 (* go: append_log.go:58:17 *)
 Definition Log__Get : val :=
   rec: "Log__Get" "log" "i" :=
-    exception_do (let: "log" := (alloc "log") in
-    let: "i" := (alloc "i") in
+    exception_do (let: "log" := (mem.alloc "log") in
+    let: "i" := (mem.alloc "i") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"m"%go (![#ptrT] "log")))) #());;;
-    let: "b" := (alloc (type.zero_val #boolT)) in
-    let: "v" := (alloc (type.zero_val #sliceT)) in
+    let: "b" := (mem.alloc (type.zero_val #boolT)) in
+    let: "v" := (mem.alloc (type.zero_val #sliceT)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := (![#uint64T] "i") in
     (method_call #append_log.append_log #"Log'ptr" #"get" (![#ptrT] "log")) "$a0") in
     let: "$r0" := "$ret0" in
@@ -128,11 +128,11 @@ Definition Log__Get : val :=
 (* go: append_log.go:65:6 *)
 Definition writeAll : val :=
   rec: "writeAll" "bks" "off" :=
-    exception_do (let: "off" := (alloc "off") in
-    let: "bks" := (alloc "bks") in
+    exception_do (let: "off" := (mem.alloc "off") in
+    let: "bks" := (mem.alloc "bks") in
     let: "$range" := (![#sliceT] "bks") in
-    (let: "bk" := (alloc (type.zero_val #intT)) in
-    let: "i" := (alloc (type.zero_val #intT)) in
+    (let: "bk" := (mem.alloc (type.zero_val #intT)) in
+    let: "i" := (mem.alloc (type.zero_val #intT)) in
     slice.for_range #sliceT "$range" (λ: "$key" "$value",
       do:  ("bk" <-[#sliceT] "$value");;;
       do:  ("i" <-[#intT] "$key");;;
@@ -143,9 +143,9 @@ Definition writeAll : val :=
 (* go: append_log.go:71:17 *)
 Definition Log__append : val :=
   rec: "Log__append" "log" "bks" :=
-    exception_do (let: "log" := (alloc "log") in
-    let: "bks" := (alloc "bks") in
-    let: "sz" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "log" := (mem.alloc "log") in
+    let: "bks" := (mem.alloc "bks") in
+    let: "sz" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (struct.field_ref #Log #"sz"%go (![#ptrT] "log"))) in
     do:  ("sz" <-[#uint64T] "$r0");;;
     (if: (s_to_w64 (let: "$a0" := (![#sliceT] "bks") in
@@ -163,10 +163,10 @@ Definition Log__append : val :=
 (* go: append_log.go:82:17 *)
 Definition Log__Append : val :=
   rec: "Log__Append" "log" "bks" :=
-    exception_do (let: "log" := (alloc "log") in
-    let: "bks" := (alloc "bks") in
+    exception_do (let: "log" := (mem.alloc "log") in
+    let: "bks" := (mem.alloc "bks") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"m"%go (![#ptrT] "log")))) #());;;
-    let: "b" := (alloc (type.zero_val #boolT)) in
+    let: "b" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "bks") in
     (method_call #append_log.append_log #"Log'ptr" #"append" (![#ptrT] "log")) "$a0") in
     do:  ("b" <-[#boolT] "$r0");;;
@@ -176,7 +176,7 @@ Definition Log__Append : val :=
 (* go: append_log.go:89:17 *)
 Definition Log__reset : val :=
   rec: "Log__reset" "log" <> :=
-    exception_do (let: "log" := (alloc "log") in
+    exception_do (let: "log" := (mem.alloc "log") in
     let: "$r0" := #(W64 0) in
     do:  ((struct.field_ref #Log #"sz"%go (![#ptrT] "log")) <-[#uint64T] "$r0");;;
     do:  ((method_call #append_log.append_log #"Log'ptr" #"writeHdr" (![#ptrT] "log")) #())).
@@ -184,7 +184,7 @@ Definition Log__reset : val :=
 (* go: append_log.go:94:17 *)
 Definition Log__Reset : val :=
   rec: "Log__Reset" "log" <> :=
-    exception_do (let: "log" := (alloc "log") in
+    exception_do (let: "log" := (mem.alloc "log") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"m"%go (![#ptrT] "log")))) #());;;
     do:  ((method_call #append_log.append_log #"Log'ptr" #"reset" (![#ptrT] "log")) #());;;
     do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Log #"m"%go (![#ptrT] "log")))) #())).

--- a/testdata/examples/async/async.gold.v
+++ b/testdata/examples/async/async.gold.v
@@ -12,14 +12,14 @@ Section code.
 (* go: async.go:6:6 *)
 Definition TakesDisk : val :=
   rec: "TakesDisk" "d" :=
-    exception_do (let: "d" := (alloc "d") in
+    exception_do (let: "d" := (mem.alloc "d") in
     do:  #()).
 
 (* go: async.go:8:6 *)
 Definition UseDisk : val :=
   rec: "UseDisk" "d" :=
-    exception_do (let: "d" := (alloc "d") in
-    let: "v" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "d" := (mem.alloc "d") in
+    let: "v" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 4096)) in
     do:  ("v" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := #(W64 0) in

--- a/testdata/examples/interfacerecursion/interfacerecursion.gold.v
+++ b/testdata/examples/interfacerecursion/interfacerecursion.gold.v
@@ -18,8 +18,8 @@ Definition c : go_type := structT [
 (* go: x.go:14:13 *)
 Definition c__Foo : val :=
   rec: "c__Foo" "c" <> :=
-    exception_do (let: "c" := (alloc "c") in
-    let: "y" := (alloc (type.zero_val #B)) in
+    exception_do (let: "c" := (mem.alloc "c") in
+    let: "y" := (mem.alloc (type.zero_val #B)) in
     let: "$r0" := (interface.make #interfacerecursion.interfacerecursion #"c'ptr" (![#ptrT] "c")) in
     do:  ("y" <-[#B] "$r0");;;
     do:  ((interface.get #"Bar"%go (![#B] "y")) #())).
@@ -27,8 +27,8 @@ Definition c__Foo : val :=
 (* go: x.go:19:13 *)
 Definition c__Bar : val :=
   rec: "c__Bar" "c" <> :=
-    exception_do (let: "c" := (alloc "c") in
-    let: "y" := (alloc (type.zero_val #A)) in
+    exception_do (let: "c" := (mem.alloc "c") in
+    let: "y" := (mem.alloc (type.zero_val #A)) in
     let: "$r0" := (interface.make #interfacerecursion.interfacerecursion #"c'ptr" (![#ptrT] "c")) in
     do:  ("y" <-[#A] "$r0");;;
     do:  ((interface.get #"Foo"%go (![#A] "y")) #())).

--- a/testdata/examples/logging2/logging2.gold.v
+++ b/testdata/examples/logging2/logging2.gold.v
@@ -32,9 +32,9 @@ Definition Log : go_type := structT [
 (* go: logging2.go:25:16 *)
 Definition Log__writeHdr : val :=
   rec: "Log__writeHdr" "log" "len" :=
-    exception_do (let: "log" := (alloc "log") in
-    let: "len" := (alloc "len") in
-    let: "hdr" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "log" := (mem.alloc "log") in
+    let: "len" := (mem.alloc "len") in
+    let: "hdr" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 4096)) in
     do:  ("hdr" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := (![#sliceT] "hdr") in
@@ -47,15 +47,15 @@ Definition Log__writeHdr : val :=
 (* go: logging2.go:31:6 *)
 Definition Init : val :=
   rec: "Init" "logSz" :=
-    exception_do (let: "logSz" := (alloc "logSz") in
-    let: "log" := (alloc (type.zero_val #Log)) in
-    let: "$r0" := (let: "$logLock" := (alloc (type.zero_val #sync.Mutex)) in
-    let: "$memLock" := (alloc (type.zero_val #sync.Mutex)) in
+    exception_do (let: "logSz" := (mem.alloc "logSz") in
+    let: "log" := (mem.alloc (type.zero_val #Log)) in
+    let: "$r0" := (let: "$logLock" := (mem.alloc (type.zero_val #sync.Mutex)) in
+    let: "$memLock" := (mem.alloc (type.zero_val #sync.Mutex)) in
     let: "$logSz" := (![#uint64T] "logSz") in
-    let: "$memLog" := (alloc (type.zero_val #sliceT)) in
-    let: "$memLen" := (alloc (type.zero_val #uint64T)) in
-    let: "$memTxnNxt" := (alloc (type.zero_val #uint64T)) in
-    let: "$logTxnNxt" := (alloc (type.zero_val #uint64T)) in
+    let: "$memLog" := (mem.alloc (type.zero_val #sliceT)) in
+    let: "$memLen" := (mem.alloc (type.zero_val #uint64T)) in
+    let: "$memTxnNxt" := (mem.alloc (type.zero_val #uint64T)) in
+    let: "$logTxnNxt" := (mem.alloc (type.zero_val #uint64T)) in
     struct.make #Log [{
       "logLock" ::= "$logLock";
       "memLock" ::= "$memLock";
@@ -73,12 +73,12 @@ Definition Init : val :=
 (* go: logging2.go:45:16 *)
 Definition Log__readHdr : val :=
   rec: "Log__readHdr" "log" <> :=
-    exception_do (let: "log" := (alloc "log") in
-    let: "hdr" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "log" := (mem.alloc "log") in
+    let: "hdr" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := LOGCOMMIT in
     (func_call #disk #"Read"%go) "$a0") in
     do:  ("hdr" <-[#sliceT] "$r0");;;
-    let: "disklen" := (alloc (type.zero_val #uint64T)) in
+    let: "disklen" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "hdr") in
     (func_call #primitive #"UInt64Get"%go) "$a0") in
     do:  ("disklen" <-[#uint64T] "$r0");;;
@@ -87,16 +87,16 @@ Definition Log__readHdr : val :=
 (* go: logging2.go:51:16 *)
 Definition Log__readBlocks : val :=
   rec: "Log__readBlocks" "log" "len" :=
-    exception_do (let: "log" := (alloc "log") in
-    let: "len" := (alloc "len") in
-    let: "blks" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "log" := (mem.alloc "log") in
+    let: "len" := (mem.alloc "len") in
+    let: "blks" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #sliceT #(W64 0)) in
     do:  ("blks" <-[#sliceT] "$r0");;;
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < (![#uint64T] "len")); (λ: <>, do:  ("i" <-[#uint64T] ((![#uint64T] "i") + #(W64 1)))) := λ: <>,
-      let: "blk" := (alloc (type.zero_val #sliceT)) in
+      let: "blk" := (mem.alloc (type.zero_val #sliceT)) in
       let: "$r0" := (let: "$a0" := (LOGSTART + (![#uint64T] "i")) in
       (func_call #disk #"Read"%go) "$a0") in
       do:  ("blk" <-[#sliceT] "$r0");;;
@@ -110,12 +110,12 @@ Definition Log__readBlocks : val :=
 (* go: logging2.go:60:16 *)
 Definition Log__Read : val :=
   rec: "Log__Read" "log" <> :=
-    exception_do (let: "log" := (alloc "log") in
+    exception_do (let: "log" := (mem.alloc "log") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"logLock"%go "log"))) #());;;
-    let: "disklen" := (alloc (type.zero_val #uint64T)) in
+    let: "disklen" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := ((method_call #logging2.logging2 #"Log" #"readHdr" (![#Log] "log")) #()) in
     do:  ("disklen" <-[#uint64T] "$r0");;;
-    let: "blks" := (alloc (type.zero_val #sliceT)) in
+    let: "blks" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#uint64T] "disklen") in
     (method_call #logging2.logging2 #"Log" #"readBlocks" (![#Log] "log")) "$a0") in
     do:  ("blks" <-[#sliceT] "$r0");;;
@@ -125,13 +125,13 @@ Definition Log__Read : val :=
 (* go: logging2.go:68:16 *)
 Definition Log__memWrite : val :=
   rec: "Log__memWrite" "log" "l" :=
-    exception_do (let: "log" := (alloc "log") in
-    let: "l" := (alloc "l") in
-    let: "n" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "log" := (mem.alloc "log") in
+    let: "l" := (mem.alloc "l") in
+    let: "n" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (s_to_w64 (let: "$a0" := (![#sliceT] "l") in
     slice.len "$a0")) in
     do:  ("n" <-[#uint64T] "$r0");;;
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < (![#uint64T] "n")); (λ: <>, do:  ("i" <-[#uint64T] ((![#uint64T] "i") + #(W64 1)))) := λ: <>,
@@ -144,8 +144,8 @@ Definition Log__memWrite : val :=
 (* go: logging2.go:75:16 *)
 Definition Log__memAppend : val :=
   rec: "Log__memAppend" "log" "l" :=
-    exception_do (let: "log" := (alloc "log") in
-    let: "l" := (alloc "l") in
+    exception_do (let: "log" := (mem.alloc "log") in
+    let: "l" := (mem.alloc "l") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"memLock"%go "log"))) #());;;
     (if: ((![#uint64T] (![#ptrT] (struct.field_ref #Log #"memLen"%go "log"))) + (s_to_w64 (let: "$a0" := (![#sliceT] "l") in
     slice.len "$a0"))) ≥ (![#uint64T] (struct.field_ref #Log #"logSz"%go "log"))
@@ -153,10 +153,10 @@ Definition Log__memAppend : val :=
       do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Log #"memLock"%go "log"))) #());;;
       return: (#false, #(W64 0))
     else do:  #());;;
-    let: "txn" := (alloc (type.zero_val #uint64T)) in
+    let: "txn" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] (struct.field_ref #Log #"memTxnNxt"%go "log"))) in
     do:  ("txn" <-[#uint64T] "$r0");;;
-    let: "n" := (alloc (type.zero_val #uint64T)) in
+    let: "n" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := ((![#uint64T] (![#ptrT] (struct.field_ref #Log #"memLen"%go "log"))) + (s_to_w64 (let: "$a0" := (![#sliceT] "l") in
     slice.len "$a0"))) in
     do:  ("n" <-[#uint64T] "$r0");;;
@@ -172,9 +172,9 @@ Definition Log__memAppend : val :=
    go: logging2.go:90:16 *)
 Definition Log__readLogTxnNxt : val :=
   rec: "Log__readLogTxnNxt" "log" <> :=
-    exception_do (let: "log" := (alloc "log") in
+    exception_do (let: "log" := (mem.alloc "log") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"memLock"%go "log"))) #());;;
-    let: "n" := (alloc (type.zero_val #uint64T)) in
+    let: "n" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] (struct.field_ref #Log #"logTxnNxt"%go "log"))) in
     do:  ("n" <-[#uint64T] "$r0");;;
     do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Log #"memLock"%go "log"))) #());;;
@@ -183,10 +183,10 @@ Definition Log__readLogTxnNxt : val :=
 (* go: logging2.go:97:16 *)
 Definition Log__diskAppendWait : val :=
   rec: "Log__diskAppendWait" "log" "txn" :=
-    exception_do (let: "log" := (alloc "log") in
-    let: "txn" := (alloc "txn") in
+    exception_do (let: "log" := (mem.alloc "log") in
+    let: "txn" := (mem.alloc "txn") in
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
-      let: "logtxn" := (alloc (type.zero_val #uint64T)) in
+      let: "logtxn" := (mem.alloc (type.zero_val #uint64T)) in
       let: "$r0" := ((method_call #logging2.logging2 #"Log" #"readLogTxnNxt" (![#Log] "log")) #()) in
       do:  ("logtxn" <-[#uint64T] "$r0");;;
       (if: (![#uint64T] "txn") < (![#uint64T] "logtxn")
@@ -197,10 +197,10 @@ Definition Log__diskAppendWait : val :=
 (* go: logging2.go:107:16 *)
 Definition Log__Append : val :=
   rec: "Log__Append" "log" "l" :=
-    exception_do (let: "log" := (alloc "log") in
-    let: "l" := (alloc "l") in
-    let: "txn" := (alloc (type.zero_val #uint64T)) in
-    let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "log" := (mem.alloc "log") in
+    let: "l" := (mem.alloc "l") in
+    let: "txn" := (mem.alloc (type.zero_val #uint64T)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := (![#sliceT] "l") in
     (method_call #logging2.logging2 #"Log" #"memAppend" (![#Log] "log")) "$a0") in
     let: "$r0" := "$ret0" in
@@ -217,18 +217,18 @@ Definition Log__Append : val :=
 (* go: logging2.go:115:16 *)
 Definition Log__writeBlocks : val :=
   rec: "Log__writeBlocks" "log" "l" "pos" :=
-    exception_do (let: "log" := (alloc "log") in
-    let: "pos" := (alloc "pos") in
-    let: "l" := (alloc "l") in
-    let: "n" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "log" := (mem.alloc "log") in
+    let: "pos" := (mem.alloc "pos") in
+    let: "l" := (mem.alloc "l") in
+    let: "n" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (s_to_w64 (let: "$a0" := (![#sliceT] "l") in
     slice.len "$a0")) in
     do:  ("n" <-[#uint64T] "$r0");;;
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < (![#uint64T] "n")); (λ: <>, do:  ("i" <-[#uint64T] ((![#uint64T] "i") + #(W64 1)))) := λ: <>,
-      let: "bk" := (alloc (type.zero_val #sliceT)) in
+      let: "bk" := (mem.alloc (type.zero_val #sliceT)) in
       let: "$r0" := (![#sliceT] (slice.elem_ref #sliceT (![#sliceT] "l") (![#uint64T] "i"))) in
       do:  ("bk" <-[#sliceT] "$r0");;;
       do:  (let: "$a0" := ((![#uint64T] "pos") + (![#uint64T] "i")) in
@@ -238,23 +238,23 @@ Definition Log__writeBlocks : val :=
 (* go: logging2.go:123:16 *)
 Definition Log__diskAppend : val :=
   rec: "Log__diskAppend" "log" <> :=
-    exception_do (let: "log" := (alloc "log") in
+    exception_do (let: "log" := (mem.alloc "log") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"logLock"%go "log"))) #());;;
-    let: "disklen" := (alloc (type.zero_val #uint64T)) in
+    let: "disklen" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := ((method_call #logging2.logging2 #"Log" #"readHdr" (![#Log] "log")) #()) in
     do:  ("disklen" <-[#uint64T] "$r0");;;
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"memLock"%go "log"))) #());;;
-    let: "memlen" := (alloc (type.zero_val #uint64T)) in
+    let: "memlen" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] (struct.field_ref #Log #"memLen"%go "log"))) in
     do:  ("memlen" <-[#uint64T] "$r0");;;
-    let: "allblks" := (alloc (type.zero_val #sliceT)) in
+    let: "allblks" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (![#sliceT] (![#ptrT] (struct.field_ref #Log #"memLog"%go "log"))) in
     do:  ("allblks" <-[#sliceT] "$r0");;;
-    let: "blks" := (alloc (type.zero_val #sliceT)) in
+    let: "blks" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$s" := (![#sliceT] "allblks") in
     slice.slice #sliceT "$s" (![#uint64T] "disklen") (slice.len "$s")) in
     do:  ("blks" <-[#sliceT] "$r0");;;
-    let: "memnxt" := (alloc (type.zero_val #uint64T)) in
+    let: "memnxt" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] (struct.field_ref #Log #"memTxnNxt"%go "log"))) in
     do:  ("memnxt" <-[#uint64T] "$r0");;;
     do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Log #"memLock"%go "log"))) #());;;
@@ -270,7 +270,7 @@ Definition Log__diskAppend : val :=
 (* go: logging2.go:142:16 *)
 Definition Log__Logger : val :=
   rec: "Log__Logger" "log" <> :=
-    exception_do (let: "log" := (alloc "log") in
+    exception_do (let: "log" := (mem.alloc "log") in
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
       do:  ((method_call #logging2.logging2 #"Log" #"diskAppend" (![#Log] "log")) #()))).
 
@@ -284,8 +284,8 @@ Definition Txn : go_type := structT [
    go: txn.go:13:6 *)
 Definition Begin : val :=
   rec: "Begin" "log" :=
-    exception_do (let: "log" := (alloc "log") in
-    let: "txn" := (alloc (type.zero_val #Txn)) in
+    exception_do (let: "log" := (mem.alloc "log") in
+    let: "txn" := (mem.alloc (type.zero_val #Txn)) in
     let: "$r0" := (let: "$log" := (![#ptrT] "log") in
     let: "$blks" := (map.make #uint64T #sliceT) in
     struct.make #Txn [{
@@ -298,13 +298,13 @@ Definition Begin : val :=
 (* go: txn.go:21:16 *)
 Definition Txn__Write : val :=
   rec: "Txn__Write" "txn" "addr" "blk" :=
-    exception_do (let: "txn" := (alloc "txn") in
-    let: "blk" := (alloc "blk") in
-    let: "addr" := (alloc "addr") in
-    let: "ret" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "txn" := (mem.alloc "txn") in
+    let: "blk" := (mem.alloc "blk") in
+    let: "addr" := (mem.alloc "addr") in
+    let: "ret" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ret" <-[#boolT] "$r0");;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: ("$ret0", "$ret1") := (map.get (![#(mapT uint64T sliceT)] (struct.field_ref #Txn #"blks"%go "txn")) (![#uint64T] "addr")) in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
@@ -330,10 +330,10 @@ Definition Txn__Write : val :=
 (* go: txn.go:38:16 *)
 Definition Txn__Read : val :=
   rec: "Txn__Read" "txn" "addr" :=
-    exception_do (let: "txn" := (alloc "txn") in
-    let: "addr" := (alloc "addr") in
-    let: "ok" := (alloc (type.zero_val #boolT)) in
-    let: "v" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "txn" := (mem.alloc "txn") in
+    let: "addr" := (mem.alloc "addr") in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
+    let: "v" := (mem.alloc (type.zero_val #sliceT)) in
     let: ("$ret0", "$ret1") := (map.get (![#(mapT uint64T sliceT)] (struct.field_ref #Txn #"blks"%go "txn")) (![#uint64T] "addr")) in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
@@ -348,12 +348,12 @@ Definition Txn__Read : val :=
 (* go: txn.go:47:16 *)
 Definition Txn__Commit : val :=
   rec: "Txn__Commit" "txn" <> :=
-    exception_do (let: "txn" := (alloc "txn") in
-    let: "blks" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "txn" := (mem.alloc "txn") in
+    let: "blks" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sliceT)) in
     do:  ("blks" <-[#ptrT] "$r0");;;
     let: "$range" := (![#(mapT uint64T sliceT)] (struct.field_ref #Txn #"blks"%go "txn")) in
-    (let: "v" := (alloc (type.zero_val #uint64T)) in
+    (let: "v" := (mem.alloc (type.zero_val #uint64T)) in
     map.for_range "$range" (λ: "$key" "value",
       do:  ("v" <-[#sliceT] "$value");;;
       do:  "$key";;;
@@ -362,7 +362,7 @@ Definition Txn__Commit : val :=
       slice.literal #sliceT ["$sl0"])) in
       (slice.append #sliceT) "$a0" "$a1") in
       do:  ((![#ptrT] "blks") <-[#sliceT] "$r0")));;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] (![#ptrT] "blks")) in
     (method_call #logging2.logging2 #"Log" #"Append" (![#Log] (![#ptrT] (struct.field_ref #Txn #"log"%go "txn")))) "$a0") in
     do:  ("ok" <-[#boolT] "$r0");;;

--- a/testdata/examples/semantics/semantics.gold.v
+++ b/testdata/examples/semantics/semantics.gold.v
@@ -17,15 +17,15 @@ Definition unit : go_type := structT [
 (* go: allocator.go:7:6 *)
 Definition findKey : val :=
   rec: "findKey" "m" :=
-    exception_do (let: "m" := (alloc "m") in
-    let: "found" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "m" := (mem.alloc "m") in
+    let: "found" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("found" <-[#uint64T] "$r0");;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #false in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$range" := (![#(mapT uint64T unit)] "m") in
-    (let: "k" := (alloc (type.zero_val #uint64T)) in
+    (let: "k" := (mem.alloc (type.zero_val #uint64T)) in
     map.for_range "$range" (λ: "$key" "value",
       do:  ("k" <-[#uint64T] "$key");;;
       (if: (~ (![#boolT] "ok"))
@@ -40,9 +40,9 @@ Definition findKey : val :=
 (* go: allocator.go:20:6 *)
 Definition allocate : val :=
   rec: "allocate" "m" :=
-    exception_do (let: "m" := (alloc "m") in
-    let: "ok" := (alloc (type.zero_val #boolT)) in
-    let: "k" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "m" := (mem.alloc "m") in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
+    let: "k" := (mem.alloc (type.zero_val #uint64T)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := (![#(mapT uint64T unit)] "m") in
     (func_call #semantics.semantics #"findKey"%go) "$a0") in
     let: "$r0" := "$ret0" in
@@ -57,11 +57,11 @@ Definition allocate : val :=
 (* go: allocator.go:26:6 *)
 Definition freeRange : val :=
   rec: "freeRange" "sz" :=
-    exception_do (let: "sz" := (alloc "sz") in
-    let: "m" := (alloc (type.zero_val #(mapT uint64T unit))) in
+    exception_do (let: "sz" := (mem.alloc "sz") in
+    let: "m" := (mem.alloc (type.zero_val #(mapT uint64T unit))) in
     let: "$r0" := (map.make #uint64T #unit) in
     do:  ("m" <-[#(mapT uint64T unit)] "$r0");;;
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < (![#uint64T] "sz")); (λ: <>, do:  ("i" <-[#uint64T] ((![#uint64T] "i") + #(W64 1)))) := λ: <>,
@@ -73,18 +73,18 @@ Definition freeRange : val :=
 (* go: allocator.go:34:6 *)
 Definition testAllocateDistinct : val :=
   rec: "testAllocateDistinct" <> :=
-    exception_do (let: "free" := (alloc (type.zero_val #(mapT uint64T unit))) in
+    exception_do (let: "free" := (mem.alloc (type.zero_val #(mapT uint64T unit))) in
     let: "$r0" := (let: "$a0" := #(W64 4) in
     (func_call #semantics.semantics #"freeRange"%go) "$a0") in
     do:  ("free" <-[#(mapT uint64T unit)] "$r0");;;
-    let: "a1" := (alloc (type.zero_val #uint64T)) in
+    let: "a1" := (mem.alloc (type.zero_val #uint64T)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := (![#(mapT uint64T unit)] "free") in
     (func_call #semantics.semantics #"allocate"%go) "$a0") in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
     do:  ("a1" <-[#uint64T] "$r0");;;
     do:  "$r1";;;
-    let: "a2" := (alloc (type.zero_val #uint64T)) in
+    let: "a2" := (mem.alloc (type.zero_val #uint64T)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := (![#(mapT uint64T unit)] "free") in
     (func_call #semantics.semantics #"allocate"%go) "$a0") in
     let: "$r0" := "$ret0" in
@@ -96,25 +96,25 @@ Definition testAllocateDistinct : val :=
 (* go: allocator.go:41:6 *)
 Definition testAllocateFull : val :=
   rec: "testAllocateFull" <> :=
-    exception_do (let: "free" := (alloc (type.zero_val #(mapT uint64T unit))) in
+    exception_do (let: "free" := (mem.alloc (type.zero_val #(mapT uint64T unit))) in
     let: "$r0" := (let: "$a0" := #(W64 2) in
     (func_call #semantics.semantics #"freeRange"%go) "$a0") in
     do:  ("free" <-[#(mapT uint64T unit)] "$r0");;;
-    let: "ok1" := (alloc (type.zero_val #boolT)) in
+    let: "ok1" := (mem.alloc (type.zero_val #boolT)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := (![#(mapT uint64T unit)] "free") in
     (func_call #semantics.semantics #"allocate"%go) "$a0") in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
     do:  "$r0";;;
     do:  ("ok1" <-[#boolT] "$r1");;;
-    let: "ok2" := (alloc (type.zero_val #boolT)) in
+    let: "ok2" := (mem.alloc (type.zero_val #boolT)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := (![#(mapT uint64T unit)] "free") in
     (func_call #semantics.semantics #"allocate"%go) "$a0") in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
     do:  "$r0";;;
     do:  ("ok2" <-[#boolT] "$r1");;;
-    let: "ok3" := (alloc (type.zero_val #boolT)) in
+    let: "ok3" := (mem.alloc (type.zero_val #boolT)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := (![#(mapT uint64T unit)] "free") in
     (func_call #semantics.semantics #"allocate"%go) "$a0") in
     let: "$r0" := "$ret0" in
@@ -126,10 +126,10 @@ Definition testAllocateFull : val :=
 (* go: block.go:3:6 *)
 Definition testExplicitBlockStmt : val :=
   rec: "testExplicitBlockStmt" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #intT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #intT)) in
     let: "$r0" := #(W64 10) in
     do:  ("x" <-[#intT] "$r0");;;
-    let: "x" := (alloc (type.zero_val #intT)) in
+    let: "x" := (mem.alloc (type.zero_val #intT)) in
     let: "$r0" := #(W64 11) in
     do:  ("x" <-[#intT] "$r0");;;
     do:  ("x" <-[#intT] ((![#intT] "x") + #(W64 1)));;;
@@ -138,7 +138,7 @@ Definition testExplicitBlockStmt : val :=
 (* go: builtin.go:3:6 *)
 Definition testMinUint64 : val :=
   rec: "testMinUint64" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 10) in
     do:  ("x" <-[#uint64T] "$r0");;;
     return: ((let: "$a0" := (![#uint64T] "x") in
@@ -148,7 +148,7 @@ Definition testMinUint64 : val :=
 (* go: builtin.go:8:6 *)
 Definition testMaxUint64 : val :=
   rec: "testMaxUint64" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 10) in
     do:  ("x" <-[#uint64T] "$r0");;;
     return: ((let: "$a0" := (![#uint64T] "x") in
@@ -162,11 +162,11 @@ Definition MultipleArgsType : go_type := funcT.
 (* go: closures.go:6:6 *)
 Definition adder : val :=
   rec: "adder" <> :=
-    exception_do (let: "sum" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "sum" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("sum" <-[#uint64T] "$r0");;;
     return: ((λ: "x",
-       exception_do (let: "x" := (alloc "x") in
+       exception_do (let: "x" := (mem.alloc "x") in
        do:  ("sum" <-[#uint64T] ((![#uint64T] "sum") + (![#uint64T] "x")));;;
        return: (![#uint64T] "sum"))
        ))).
@@ -174,13 +174,13 @@ Definition adder : val :=
 (* go: closures.go:14:6 *)
 Definition testClosureBasic : val :=
   rec: "testClosureBasic" <> :=
-    exception_do (let: "pos" := (alloc (type.zero_val #funcT)) in
+    exception_do (let: "pos" := (mem.alloc (type.zero_val #funcT)) in
     let: "$r0" := ((func_call #semantics.semantics #"adder"%go) #()) in
     do:  ("pos" <-[#funcT] "$r0");;;
-    let: "doub" := (alloc (type.zero_val #funcT)) in
+    let: "doub" := (mem.alloc (type.zero_val #funcT)) in
     let: "$r0" := ((func_call #semantics.semantics #"adder"%go) #()) in
     do:  ("doub" <-[#funcT] "$r0");;;
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < #(W64 10)); (λ: <>, do:  ("i" <-[#uint64T] ((![#uint64T] "i") + #(W64 1)))) := λ: <>,
@@ -198,10 +198,10 @@ Definition testClosureBasic : val :=
 (* go: comparisons.go:3:6 *)
 Definition testCompareAll : val :=
   rec: "testCompareAll" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "nok" := (alloc (type.zero_val #boolT)) in
+    let: "nok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #false in
     do:  ("nok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && #(1 <? 2)) in
@@ -222,13 +222,13 @@ Definition testCompareAll : val :=
 (* go: comparisons.go:20:6 *)
 Definition testCompareGT : val :=
   rec: "testCompareGT" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 4) in
     do:  ("x" <-[#uint64T] "$r0");;;
-    let: "y" := (alloc (type.zero_val #uint64T)) in
+    let: "y" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 5) in
     do:  ("y" <-[#uint64T] "$r0");;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((![#uint64T] "y") > #(W64 4))) in
@@ -240,13 +240,13 @@ Definition testCompareGT : val :=
 (* go: comparisons.go:31:6 *)
 Definition testCompareGE : val :=
   rec: "testCompareGE" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 4) in
     do:  ("x" <-[#uint64T] "$r0");;;
-    let: "y" := (alloc (type.zero_val #uint64T)) in
+    let: "y" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 5) in
     do:  ("y" <-[#uint64T] "$r0");;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((![#uint64T] "y") ≥ #(W64 4))) in
@@ -263,13 +263,13 @@ Definition testCompareGE : val :=
 (* go: comparisons.go:47:6 *)
 Definition testCompareLT : val :=
   rec: "testCompareLT" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 4) in
     do:  ("x" <-[#uint64T] "$r0");;;
-    let: "y" := (alloc (type.zero_val #uint64T)) in
+    let: "y" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 5) in
     do:  ("y" <-[#uint64T] "$r0");;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((![#uint64T] "y") < #(W64 6))) in
@@ -281,13 +281,13 @@ Definition testCompareLT : val :=
 (* go: comparisons.go:58:6 *)
 Definition testCompareLE : val :=
   rec: "testCompareLE" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 4) in
     do:  ("x" <-[#uint64T] "$r0");;;
-    let: "y" := (alloc (type.zero_val #uint64T)) in
+    let: "y" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 5) in
     do:  ("y" <-[#uint64T] "$r0");;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((![#uint64T] "y") ≤ #(W64 6))) in
@@ -304,7 +304,7 @@ Definition testCompareLE : val :=
 (* go: conversions.go:5:6 *)
 Definition literalCast : val :=
   rec: "literalCast" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 2) in
     do:  ("x" <-[#uint64T] "$r0");;;
     return: ((![#uint64T] "x") + #(W64 2))).
@@ -312,8 +312,8 @@ Definition literalCast : val :=
 (* go: conversions.go:11:6 *)
 Definition stringToByteSlice : val :=
   rec: "stringToByteSlice" "s" :=
-    exception_do (let: "s" := (alloc "s") in
-    let: "p" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "s" := (mem.alloc "s") in
+    let: "p" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (string.to_bytes (![#stringT] "s")) in
     do:  ("p" <-[#sliceT] "$r0");;;
     return: (![#sliceT] "p")).
@@ -321,7 +321,7 @@ Definition stringToByteSlice : val :=
 (* go: conversions.go:17:6 *)
 Definition byteSliceToString : val :=
   rec: "byteSliceToString" "p" :=
-    exception_do (let: "p" := (alloc "p") in
+    exception_do (let: "p" := (mem.alloc "p") in
     return: (string.from_bytes (![#sliceT] "p"))).
 
 (* tests
@@ -329,7 +329,7 @@ Definition byteSliceToString : val :=
    go: conversions.go:23:6 *)
 Definition testByteSliceToString : val :=
   rec: "testByteSliceToString" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 3)) in
     do:  ("x" <-[#sliceT] "$r0");;;
     let: "$r0" := #(W8 65) in
@@ -344,12 +344,12 @@ Definition testByteSliceToString : val :=
 (* go: copy.go:3:6 *)
 Definition testCopySimple : val :=
   rec: "testCopySimple" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 10)) in
     do:  ("x" <-[#sliceT] "$r0");;;
     let: "$r0" := #(W8 1) in
     do:  ((slice.elem_ref #byteT (![#sliceT] "x") #(W64 3)) <-[#byteT] "$r0");;;
-    let: "y" := (alloc (type.zero_val #sliceT)) in
+    let: "y" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 10)) in
     do:  ("y" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := (![#sliceT] "y") in
@@ -360,17 +360,17 @@ Definition testCopySimple : val :=
 (* go: copy.go:11:6 *)
 Definition testCopyShorterDst : val :=
   rec: "testCopyShorterDst" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 15)) in
     do:  ("x" <-[#sliceT] "$r0");;;
     let: "$r0" := #(W8 1) in
     do:  ((slice.elem_ref #byteT (![#sliceT] "x") #(W64 3)) <-[#byteT] "$r0");;;
     let: "$r0" := #(W8 2) in
     do:  ((slice.elem_ref #byteT (![#sliceT] "x") #(W64 12)) <-[#byteT] "$r0");;;
-    let: "y" := (alloc (type.zero_val #sliceT)) in
+    let: "y" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 10)) in
     do:  ("y" <-[#sliceT] "$r0");;;
-    let: "n" := (alloc (type.zero_val #uint64T)) in
+    let: "n" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (s_to_w64 (let: "$a0" := (![#sliceT] "y") in
     let: "$a1" := (![#sliceT] "x") in
     (slice.copy #byteT) "$a0" "$a1")) in
@@ -380,17 +380,17 @@ Definition testCopyShorterDst : val :=
 (* go: copy.go:20:6 *)
 Definition testCopyShorterSrc : val :=
   rec: "testCopyShorterSrc" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 10)) in
     do:  ("x" <-[#sliceT] "$r0");;;
-    let: "y" := (alloc (type.zero_val #sliceT)) in
+    let: "y" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 15)) in
     do:  ("y" <-[#sliceT] "$r0");;;
     let: "$r0" := #(W8 1) in
     do:  ((slice.elem_ref #byteT (![#sliceT] "x") #(W64 3)) <-[#byteT] "$r0");;;
     let: "$r0" := #(W8 2) in
     do:  ((slice.elem_ref #byteT (![#sliceT] "y") #(W64 12)) <-[#byteT] "$r0");;;
-    let: "n" := (alloc (type.zero_val #uint64T)) in
+    let: "n" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (s_to_w64 (let: "$a0" := (![#sliceT] "y") in
     let: "$a1" := (![#sliceT] "x") in
     (slice.copy #byteT) "$a0" "$a1")) in
@@ -400,10 +400,10 @@ Definition testCopyShorterSrc : val :=
 (* go: defer.go:3:6 *)
 Definition deferSimple : val :=
   rec: "deferSimple" <> :=
-    with_defer: (let: "x" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #uint64T)) in
+    with_defer: (let: "x" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("x" <-[#ptrT] "$r0");;;
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < #(W64 10)); (λ: <>, do:  ("i" <-[#uint64T] ((![#uint64T] "i") + #(W64 1)))) := λ: <>,
@@ -425,10 +425,10 @@ Definition testDefer : val :=
 (* go: defer.go:17:6 *)
 Definition testDeferFuncLit : val :=
   rec: "testDeferFuncLit" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #intT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #intT)) in
     let: "$r0" := #(W64 10) in
     do:  ("x" <-[#intT] "$r0");;;
-    let: "f" := (alloc (type.zero_val #funcT)) in
+    let: "f" := (mem.alloc (type.zero_val #funcT)) in
     let: "$r0" := (λ: <>,
       with_defer: (do:  (let: "$f" := (λ: <>,
         exception_do (do:  ("x" <-[#intT] ((![#intT] "x") + #(W64 1))))
@@ -450,9 +450,9 @@ Definition Enc : go_type := structT [
 (* go: encoding.go:10:15 *)
 Definition Enc__consume : val :=
   rec: "Enc__consume" "e" "n" :=
-    exception_do (let: "e" := (alloc "e") in
-    let: "n" := (alloc "n") in
-    let: "b" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "e" := (mem.alloc "e") in
+    let: "n" := (mem.alloc "n") in
+    let: "b" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$s" := (![#sliceT] (struct.field_ref #Enc #"p"%go (![#ptrT] "e"))) in
     slice.slice #byteT "$s" #(W64 0) (![#uint64T] "n")) in
     do:  ("b" <-[#sliceT] "$r0");;;
@@ -468,9 +468,9 @@ Definition Dec : go_type := structT [
 (* go: encoding.go:20:15 *)
 Definition Dec__consume : val :=
   rec: "Dec__consume" "d" "n" :=
-    exception_do (let: "d" := (alloc "d") in
-    let: "n" := (alloc "n") in
-    let: "b" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "d" := (mem.alloc "d") in
+    let: "n" := (mem.alloc "n") in
+    let: "b" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$s" := (![#sliceT] (struct.field_ref #Dec #"p"%go (![#ptrT] "d"))) in
     slice.slice #byteT "$s" #(W64 0) (![#uint64T] "n")) in
     do:  ("b" <-[#sliceT] "$r0");;;
@@ -482,18 +482,18 @@ Definition Dec__consume : val :=
 (* go: encoding.go:26:6 *)
 Definition roundtripEncDec32 : val :=
   rec: "roundtripEncDec32" "x" :=
-    exception_do (let: "x" := (alloc "x") in
-    let: "r" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "x" := (mem.alloc "x") in
+    let: "r" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 4)) in
     do:  ("r" <-[#sliceT] "$r0");;;
-    let: "e" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (let: "$p" := (![#sliceT] "r") in
+    let: "e" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (let: "$p" := (![#sliceT] "r") in
     struct.make #Enc [{
       "p" ::= "$p"
     }])) in
     do:  ("e" <-[#ptrT] "$r0");;;
-    let: "d" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (let: "$p" := (![#sliceT] "r") in
+    let: "d" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (let: "$p" := (![#sliceT] "r") in
     struct.make #Dec [{
       "p" ::= "$p"
     }])) in
@@ -509,18 +509,18 @@ Definition roundtripEncDec32 : val :=
 (* go: encoding.go:34:6 *)
 Definition roundtripEncDec64 : val :=
   rec: "roundtripEncDec64" "x" :=
-    exception_do (let: "x" := (alloc "x") in
-    let: "r" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "x" := (mem.alloc "x") in
+    let: "r" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 8)) in
     do:  ("r" <-[#sliceT] "$r0");;;
-    let: "e" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (let: "$p" := (![#sliceT] "r") in
+    let: "e" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (let: "$p" := (![#sliceT] "r") in
     struct.make #Enc [{
       "p" ::= "$p"
     }])) in
     do:  ("e" <-[#ptrT] "$r0");;;
-    let: "d" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (let: "$p" := (![#sliceT] "r") in
+    let: "d" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (let: "$p" := (![#sliceT] "r") in
     struct.make #Dec [{
       "p" ::= "$p"
     }])) in
@@ -538,7 +538,7 @@ Definition roundtripEncDec64 : val :=
    go: encoding.go:43:6 *)
 Definition testEncDec32Simple : val :=
   rec: "testEncDec32Simple" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((let: "$a0" := #(W32 0) in
@@ -555,7 +555,7 @@ Definition testEncDec32Simple : val :=
 (* go: encoding.go:51:6 *)
 Definition failing_testEncDec32 : val :=
   rec: "failing_testEncDec32" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((let: "$a0" := #(W32 3434807466) in
@@ -581,7 +581,7 @@ Definition failing_testEncDec32 : val :=
 (* go: encoding.go:62:6 *)
 Definition testEncDec64Simple : val :=
   rec: "testEncDec64Simple" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((let: "$a0" := #(W64 0) in
@@ -598,7 +598,7 @@ Definition testEncDec64Simple : val :=
 (* go: encoding.go:70:6 *)
 Definition testEncDec64 : val :=
   rec: "testEncDec64" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((let: "$a0" := #(W64 62206846038638762) in
@@ -630,14 +630,14 @@ Definition testEncDec64 : val :=
 (* go: first_class_function.go:3:6 *)
 Definition FirstClassFunction : val :=
   rec: "FirstClassFunction" "a" :=
-    exception_do (let: "a" := (alloc "a") in
+    exception_do (let: "a" := (mem.alloc "a") in
     return: ((![#uint64T] "a") + #(W64 10))).
 
 (* go: first_class_function.go:7:6 *)
 Definition ApplyF : val :=
   rec: "ApplyF" "a" "f" :=
-    exception_do (let: "f" := (alloc "f") in
-    let: "a" := (alloc "a") in
+    exception_do (let: "f" := (mem.alloc "f") in
+    let: "a" := (mem.alloc "a") in
     return: (let: "$a0" := (![#uint64T] "a") in
      (![#funcT] "f") "$a0")).
 
@@ -659,9 +659,9 @@ Definition Editor : go_type := structT [
    go: function_ordering.go:11:18 *)
 Definition Editor__AdvanceReturn : val :=
   rec: "Editor__AdvanceReturn" "e" "next" :=
-    exception_do (let: "e" := (alloc "e") in
-    let: "next" := (alloc "next") in
-    let: "tmp" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "e" := (mem.alloc "e") in
+    let: "next" := (mem.alloc "next") in
+    let: "tmp" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (struct.field_ref #Editor #"next_val"%go (![#ptrT] "e"))) in
     do:  ("tmp" <-[#uint64T] "$r0");;;
     let: "$r0" := (![#uint64T] "tmp") in
@@ -679,10 +679,10 @@ Definition Editor__AdvanceReturn : val :=
    go: function_ordering.go:21:6 *)
 Definition addFour64 : val :=
   rec: "addFour64" "a" "b" "c" "d" :=
-    exception_do (let: "d" := (alloc "d") in
-    let: "c" := (alloc "c") in
-    let: "b" := (alloc "b") in
-    let: "a" := (alloc "a") in
+    exception_do (let: "d" := (mem.alloc "d") in
+    let: "c" := (mem.alloc "c") in
+    let: "b" := (mem.alloc "b") in
+    let: "a" := (mem.alloc "a") in
     return: ((((![#uint64T] "a") + (![#uint64T] "b")) + (![#uint64T] "c")) + (![#uint64T] "d"))).
 
 Definition Pair : go_type := structT [
@@ -695,10 +695,10 @@ Definition Pair : go_type := structT [
    go: function_ordering.go:31:6 *)
 Definition failing_testFunctionOrdering : val :=
   rec: "failing_testFunctionOrdering" <> :=
-    exception_do (let: "arr" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "arr" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #uint64T #(W64 5)) in
     do:  ("arr" <-[#sliceT] "$r0");;;
-    let: "e1" := (alloc (type.zero_val #Editor)) in
+    let: "e1" := (mem.alloc (type.zero_val #Editor)) in
     let: "$r0" := (let: "$s" := (let: "$s" := (![#sliceT] "arr") in
     slice.slice #uint64T "$s" #(W64 0) (slice.len "$s")) in
     let: "$next_val" := #(W64 1) in
@@ -707,7 +707,7 @@ Definition failing_testFunctionOrdering : val :=
       "next_val" ::= "$next_val"
     }]) in
     do:  ("e1" <-[#Editor] "$r0");;;
-    let: "e2" := (alloc (type.zero_val #Editor)) in
+    let: "e2" := (mem.alloc (type.zero_val #Editor)) in
     let: "$r0" := (let: "$s" := (let: "$s" := (![#sliceT] "arr") in
     slice.slice #uint64T "$s" #(W64 0) (slice.len "$s")) in
     let: "$next_val" := #(W64 101) in
@@ -741,7 +741,7 @@ Definition failing_testFunctionOrdering : val :=
     (if: (![#uint64T] (slice.elem_ref #uint64T (![#sliceT] "arr") #(W64 2))) ≠ #(W64 3)
     then return: (#false)
     else do:  #());;;
-    let: "p" := (alloc (type.zero_val #Pair)) in
+    let: "p" := (mem.alloc (type.zero_val #Pair)) in
     let: "$r0" := (let: "$x" := (let: "$a0" := #(W64 5) in
     (method_call #semantics.semantics #"Editor'ptr" #"AdvanceReturn" "e1") "$a0") in
     let: "$y" := (let: "$a0" := #(W64 105) in
@@ -754,7 +754,7 @@ Definition failing_testFunctionOrdering : val :=
     (if: (![#uint64T] (slice.elem_ref #uint64T (![#sliceT] "arr") #(W64 3))) ≠ #(W64 104)
     then return: (#false)
     else do:  #());;;
-    let: "q" := (alloc (type.zero_val #Pair)) in
+    let: "q" := (mem.alloc (type.zero_val #Pair)) in
     let: "$r0" := (let: "$y" := (let: "$a0" := #(W64 6) in
     (method_call #semantics.semantics #"Editor'ptr" #"AdvanceReturn" "e1") "$a0") in
     let: "$x" := (let: "$a0" := #(W64 106) in
@@ -772,8 +772,8 @@ Definition failing_testFunctionOrdering : val :=
 (* go: function_ordering.go:74:6 *)
 Definition storeAndReturn : val :=
   rec: "storeAndReturn" "x" "v" :=
-    exception_do (let: "v" := (alloc "v") in
-    let: "x" := (alloc "x") in
+    exception_do (let: "v" := (mem.alloc "v") in
+    let: "x" := (mem.alloc "x") in
     let: "$r0" := (![#uint64T] "v") in
     do:  ((![#ptrT] "x") <-[#uint64T] "$r0");;;
     return: (![#uint64T] "v")).
@@ -784,7 +784,7 @@ Definition storeAndReturn : val :=
    go: function_ordering.go:81:6 *)
 Definition failing_testArgumentOrder : val :=
   rec: "failing_testArgumentOrder" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("x" <-[#uint64T] "$r0");;;
     do:  (let: "$a0" := (let: "$a0" := "x" in
@@ -800,7 +800,7 @@ Definition failing_testArgumentOrder : val :=
     let: "$a1" := #(W64 4) in
     (func_call #semantics.semantics #"storeAndReturn"%go) "$a0" "$a1") in
     (func_call #semantics.semantics #"addFour64"%go) "$a0" "$a1" "$a2" "$a3");;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := ((![#uint64T] "x") = #(W64 4)) in
     do:  ("ok" <-[#boolT] "$r0");;;
     return: (![#boolT] "ok")).
@@ -808,13 +808,13 @@ Definition failing_testArgumentOrder : val :=
 (* go: int_conversions.go:3:6 *)
 Definition testU64ToU32 : val :=
   rec: "testU64ToU32" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "x" := (alloc (type.zero_val #uint64T)) in
+    let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 1230) in
     do:  ("x" <-[#uint64T] "$r0");;;
-    let: "y" := (alloc (type.zero_val #uint32T)) in
+    let: "y" := (mem.alloc (type.zero_val #uint32T)) in
     let: "$r0" := #(W32 1230) in
     do:  ("y" <-[#uint32T] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((u_to_w32 (![#uint64T] "x")) = (![#uint32T] "y"))) in
@@ -826,7 +826,7 @@ Definition testU64ToU32 : val :=
 (* go: int_conversions.go:12:6 *)
 Definition testU32Len : val :=
   rec: "testU32Len" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 100)) in
     do:  ("s" <-[#sliceT] "$r0");;;
     return: ((s_to_w32 (let: "$a0" := (![#sliceT] "s") in
@@ -839,7 +839,7 @@ Definition Uint32 : go_type := uint32T.
    go: int_conversions.go:20:6 *)
 Definition failing_testU32NewtypeLen : val :=
   rec: "failing_testU32NewtypeLen" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 20)) in
     do:  ("s" <-[#sliceT] "$r0");;;
     return: ((s_to_w32 (let: "$a0" := (![#sliceT] "s") in
@@ -850,21 +850,21 @@ Definition geometryInterface : go_type := interfaceT.
 (* go: interfaces.go:12:6 *)
 Definition measureArea : val :=
   rec: "measureArea" "t" :=
-    exception_do (let: "t" := (alloc "t") in
+    exception_do (let: "t" := (mem.alloc "t") in
     return: ((interface.get #"Square"%go (![#geometryInterface] "t")) #())).
 
 (* go: interfaces.go:16:6 *)
 Definition measureVolumePlusNM : val :=
   rec: "measureVolumePlusNM" "t" "n" "m" :=
-    exception_do (let: "m" := (alloc "m") in
-    let: "n" := (alloc "n") in
-    let: "t" := (alloc "t") in
+    exception_do (let: "m" := (mem.alloc "m") in
+    let: "n" := (mem.alloc "n") in
+    let: "t" := (mem.alloc "t") in
     return: ((((interface.get #"Volume"%go (![#geometryInterface] "t")) #()) + (![#uint64T] "n")) + (![#uint64T] "m"))).
 
 (* go: interfaces.go:20:6 *)
 Definition measureVolume : val :=
   rec: "measureVolume" "t" :=
-    exception_do (let: "t" := (alloc "t") in
+    exception_do (let: "t" := (mem.alloc "t") in
     return: ((interface.get #"Volume"%go (![#geometryInterface] "t")) #())).
 
 Definition SquareStruct : go_type := structT [
@@ -874,19 +874,19 @@ Definition SquareStruct : go_type := structT [
 (* go: interfaces.go:28:23 *)
 Definition SquareStruct__Square : val :=
   rec: "SquareStruct__Square" "t" <> :=
-    exception_do (let: "t" := (alloc "t") in
+    exception_do (let: "t" := (mem.alloc "t") in
     return: ((![#uint64T] (struct.field_ref #SquareStruct #"Side"%go "t")) * (![#uint64T] (struct.field_ref #SquareStruct #"Side"%go "t")))).
 
 (* go: interfaces.go:32:23 *)
 Definition SquareStruct__Volume : val :=
   rec: "SquareStruct__Volume" "t" <> :=
-    exception_do (let: "t" := (alloc "t") in
+    exception_do (let: "t" := (mem.alloc "t") in
     return: (((![#uint64T] (struct.field_ref #SquareStruct #"Side"%go "t")) * (![#uint64T] (struct.field_ref #SquareStruct #"Side"%go "t"))) * (![#uint64T] (struct.field_ref #SquareStruct #"Side"%go "t")))).
 
 (* go: interfaces.go:40:6 *)
 Definition testBasicInterface : val :=
   rec: "testBasicInterface" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #SquareStruct)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #SquareStruct)) in
     let: "$r0" := (let: "$Side" := #(W64 2) in
     struct.make #SquareStruct [{
       "Side" ::= "$Side"
@@ -898,13 +898,13 @@ Definition testBasicInterface : val :=
 (* go: interfaces.go:47:6 *)
 Definition testAssignInterface : val :=
   rec: "testAssignInterface" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #SquareStruct)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #SquareStruct)) in
     let: "$r0" := (let: "$Side" := #(W64 3) in
     struct.make #SquareStruct [{
       "Side" ::= "$Side"
     }]) in
     do:  ("s" <-[#SquareStruct] "$r0");;;
-    let: "area" := (alloc (type.zero_val #uint64T)) in
+    let: "area" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (interface.make #semantics.semantics #"SquareStruct" (![#SquareStruct] "s")) in
     (func_call #semantics.semantics #"measureArea"%go) "$a0") in
     do:  ("area" <-[#uint64T] "$r0");;;
@@ -913,17 +913,17 @@ Definition testAssignInterface : val :=
 (* go: interfaces.go:55:6 *)
 Definition testMultipleInterface : val :=
   rec: "testMultipleInterface" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #SquareStruct)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #SquareStruct)) in
     let: "$r0" := (let: "$Side" := #(W64 3) in
     struct.make #SquareStruct [{
       "Side" ::= "$Side"
     }]) in
     do:  ("s" <-[#SquareStruct] "$r0");;;
-    let: "square1" := (alloc (type.zero_val #uint64T)) in
+    let: "square1" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (interface.make #semantics.semantics #"SquareStruct" (![#SquareStruct] "s")) in
     (func_call #semantics.semantics #"measureArea"%go) "$a0") in
     do:  ("square1" <-[#uint64T] "$r0");;;
-    let: "square2" := (alloc (type.zero_val #uint64T)) in
+    let: "square2" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (interface.make #semantics.semantics #"SquareStruct" (![#SquareStruct] "s")) in
     (func_call #semantics.semantics #"measureArea"%go) "$a0") in
     do:  ("square2" <-[#uint64T] "$r0");;;
@@ -932,17 +932,17 @@ Definition testMultipleInterface : val :=
 (* go: interfaces.go:64:6 *)
 Definition testBinaryExprInterface : val :=
   rec: "testBinaryExprInterface" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #SquareStruct)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #SquareStruct)) in
     let: "$r0" := (let: "$Side" := #(W64 3) in
     struct.make #SquareStruct [{
       "Side" ::= "$Side"
     }]) in
     do:  ("s" <-[#SquareStruct] "$r0");;;
-    let: "square1" := (alloc (type.zero_val #uint64T)) in
+    let: "square1" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (interface.make #semantics.semantics #"SquareStruct" (![#SquareStruct] "s")) in
     (func_call #semantics.semantics #"measureArea"%go) "$a0") in
     do:  ("square1" <-[#uint64T] "$r0");;;
-    let: "square2" := (alloc (type.zero_val #uint64T)) in
+    let: "square2" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (interface.make #semantics.semantics #"SquareStruct" (![#SquareStruct] "s")) in
     (func_call #semantics.semantics #"measureVolume"%go) "$a0") in
     do:  ("square2" <-[#uint64T] "$r0");;;
@@ -953,7 +953,7 @@ Definition testBinaryExprInterface : val :=
 (* go: interfaces.go:73:6 *)
 Definition testIfStmtInterface : val :=
   rec: "testIfStmtInterface" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #SquareStruct)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #SquareStruct)) in
     let: "$r0" := (let: "$Side" := #(W64 3) in
     struct.make #SquareStruct [{
       "Side" ::= "$Side"
@@ -971,8 +971,8 @@ Definition testIfStmtInterface : val :=
    go: lock.go:7:6 *)
 Definition testsUseLocks : val :=
   rec: "testsUseLocks" <> :=
-    exception_do (let: "m" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    exception_do (let: "m" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("m" <-[#ptrT] "$r0");;;
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] "m")) #());;;
     do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] "m")) #());;;
@@ -983,21 +983,21 @@ Definition testsUseLocks : val :=
    go: loops.go:4:6 *)
 Definition standardForLoop : val :=
   rec: "standardForLoop" "s" :=
-    exception_do (let: "s" := (alloc "s") in
-    let: "sumPtr" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "s" := (mem.alloc "s") in
+    let: "sumPtr" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("sumPtr" <-[#ptrT] "$r0");;;
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
       (if: (![#uint64T] "i") < (s_to_w64 (let: "$a0" := (![#sliceT] "s") in
       slice.len "$a0"))
       then
-        let: "sum" := (alloc (type.zero_val #uint64T)) in
+        let: "sum" := (mem.alloc (type.zero_val #uint64T)) in
         let: "$r0" := (![#uint64T] (![#ptrT] "sumPtr")) in
         do:  ("sum" <-[#uint64T] "$r0");;;
-        let: "x" := (alloc (type.zero_val #uint64T)) in
+        let: "x" := (mem.alloc (type.zero_val #uint64T)) in
         let: "$r0" := (![#uint64T] (slice.elem_ref #uint64T (![#sliceT] "s") (![#uint64T] "i"))) in
         do:  ("x" <-[#uint64T] "$r0");;;
         let: "$r0" := ((![#uint64T] "sum") + (![#uint64T] "x")) in
@@ -1007,7 +1007,7 @@ Definition standardForLoop : val :=
         continue: #()
       else do:  #());;;
       break: #()));;;
-    let: "sum" := (alloc (type.zero_val #uint64T)) in
+    let: "sum" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] "sumPtr")) in
     do:  ("sum" <-[#uint64T] "$r0");;;
     return: (![#uint64T] "sum")).
@@ -1019,10 +1019,10 @@ Definition LoopStruct : go_type := structT [
 (* go: loops.go:28:22 *)
 Definition LoopStruct__forLoopWait : val :=
   rec: "LoopStruct__forLoopWait" "ls" "i" :=
-    exception_do (let: "ls" := (alloc "ls") in
-    let: "i" := (alloc "i") in
+    exception_do (let: "ls" := (mem.alloc "ls") in
+    let: "i" := (mem.alloc "i") in
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
-      let: "nxt" := (alloc (type.zero_val #ptrT)) in
+      let: "nxt" := (mem.alloc (type.zero_val #ptrT)) in
       let: "$r0" := (![#ptrT] (struct.field_ref #LoopStruct #"loopNext"%go "ls")) in
       do:  ("nxt" <-[#ptrT] "$r0");;;
       (if: (![#uint64T] "i") < (![#uint64T] (![#ptrT] "nxt"))
@@ -1037,7 +1037,7 @@ Definition LoopStruct__forLoopWait : val :=
    go: loops.go:40:6 *)
 Definition testStandardForLoop : val :=
   rec: "testStandardForLoop" <> :=
-    exception_do (let: "arr" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "arr" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #uint64T #(W64 4)) in
     do:  ("arr" <-[#sliceT] "$r0");;;
     do:  ((slice.elem_ref #uint64T (![#sliceT] "arr") #(W64 0)) <-[#uint64T] ((![#uint64T] (slice.elem_ref #uint64T (![#sliceT] "arr") #(W64 0))) + #(W64 1)));;;
@@ -1050,8 +1050,8 @@ Definition testStandardForLoop : val :=
 (* go: loops.go:49:6 *)
 Definition testForLoopWait : val :=
   rec: "testForLoopWait" <> :=
-    exception_do (let: "ls" := (alloc (type.zero_val #LoopStruct)) in
-    let: "$r0" := (let: "$loopNext" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "ls" := (mem.alloc (type.zero_val #LoopStruct)) in
+    let: "$r0" := (let: "$loopNext" := (mem.alloc (type.zero_val #uint64T)) in
     struct.make #LoopStruct [{
       "loopNext" ::= "$loopNext"
     }]) in
@@ -1063,7 +1063,7 @@ Definition testForLoopWait : val :=
 (* go: loops.go:59:6 *)
 Definition testBreakFromLoopWithContinue : val :=
   rec: "testBreakFromLoopWithContinue" <> :=
-    exception_do (let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
@@ -1079,7 +1079,7 @@ Definition testBreakFromLoopWithContinue : val :=
 (* go: loops.go:71:6 *)
 Definition testBreakFromLoopNoContinue : val :=
   rec: "testBreakFromLoopNoContinue" <> :=
-    exception_do (let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < #(W64 3)); (λ: <>, Skip) := λ: <>,
@@ -1096,7 +1096,7 @@ Definition testBreakFromLoopNoContinue : val :=
 (* go: loops.go:83:6 *)
 Definition testBreakFromLoopNoContinueDouble : val :=
   rec: "testBreakFromLoopNoContinueDouble" <> :=
-    exception_do (let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < #(W64 3)); (λ: <>, Skip) := λ: <>,
@@ -1115,7 +1115,7 @@ Definition testBreakFromLoopNoContinueDouble : val :=
 (* go: loops.go:96:6 *)
 Definition testBreakFromLoopForOnly : val :=
   rec: "testBreakFromLoopForOnly" <> :=
-    exception_do (let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < #(W64 3)); (λ: <>, Skip) := λ: <>,
@@ -1126,7 +1126,7 @@ Definition testBreakFromLoopForOnly : val :=
 (* go: loops.go:104:6 *)
 Definition testBreakFromLoopAssignAndContinue : val :=
   rec: "testBreakFromLoopAssignAndContinue" <> :=
-    exception_do (let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < #(W64 3)); (λ: <>, Skip) := λ: <>,
@@ -1144,17 +1144,17 @@ Definition testBreakFromLoopAssignAndContinue : val :=
 (* go: loops.go:117:6 *)
 Definition testNestedLoops : val :=
   rec: "testNestedLoops" <> :=
-    exception_do (let: "ok1" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok1" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #false in
     do:  ("ok1" <-[#boolT] "$r0");;;
-    let: "ok2" := (alloc (type.zero_val #boolT)) in
+    let: "ok2" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #false in
     do:  ("ok2" <-[#boolT] "$r0");;;
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
-      (let: "j" := (alloc (type.zero_val #uint64T)) in
+      (let: "j" := (mem.alloc (type.zero_val #uint64T)) in
       let: "$r0" := #(W64 0) in
       do:  ("j" <-[#uint64T] "$r0");;;
       (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
@@ -1176,14 +1176,14 @@ Definition testNestedLoops : val :=
 (* go: loops.go:136:6 *)
 Definition testNestedGoStyleLoops : val :=
   rec: "testNestedGoStyleLoops" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #false in
     do:  ("ok" <-[#boolT] "$r0");;;
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < #(W64 10)); (λ: <>, do:  ("i" <-[#uint64T] ((![#uint64T] "i") + #(W64 1)))) := λ: <>,
-      (let: "j" := (alloc (type.zero_val #uint64T)) in
+      (let: "j" := (mem.alloc (type.zero_val #uint64T)) in
       let: "$r0" := #(W64 0) in
       do:  ("j" <-[#uint64T] "$r0");;;
       (for: (λ: <>, (![#uint64T] "j") < (![#uint64T] "i")); (λ: <>, do:  ("j" <-[#uint64T] ((![#uint64T] "j") + #(W64 1)))) := λ: <>,
@@ -1198,14 +1198,14 @@ Definition testNestedGoStyleLoops : val :=
 (* go: loops.go:150:6 *)
 Definition testNestedGoStyleLoopsNoComparison : val :=
   rec: "testNestedGoStyleLoopsNoComparison" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #false in
     do:  ("ok" <-[#boolT] "$r0");;;
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < #(W64 10)); (λ: <>, do:  ("i" <-[#uint64T] ((![#uint64T] "i") + #(W64 1)))) := λ: <>,
-      (let: "j" := (alloc (type.zero_val #uint64T)) in
+      (let: "j" := (mem.alloc (type.zero_val #uint64T)) in
       let: "$r0" := #(W64 0) in
       do:  ("j" <-[#uint64T] "$r0");;;
       (for: (λ: <>, (![#uint64T] "j") < (![#uint64T] "i")); (λ: <>, do:  ("j" <-[#uint64T] ((![#uint64T] "j") + #(W64 1)))) := λ: <>,
@@ -1220,10 +1220,10 @@ Definition testNestedGoStyleLoopsNoComparison : val :=
 (* go: maps.go:3:6 *)
 Definition IterateMapKeys : val :=
   rec: "IterateMapKeys" "m" :=
-    exception_do (let: "m" := (alloc "m") in
-    let: "sum" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "m" := (mem.alloc "m") in
+    let: "sum" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$range" := (![#(mapT uint64T uint64T)] "m") in
-    (let: "k" := (alloc (type.zero_val #uint64T)) in
+    (let: "k" := (mem.alloc (type.zero_val #uint64T)) in
     map.for_range "$range" (λ: "$key" "value",
       do:  ("k" <-[#uint64T] "$key");;;
       let: "$r0" := ((![#uint64T] "sum") + (![#uint64T] "k")) in
@@ -1233,10 +1233,10 @@ Definition IterateMapKeys : val :=
 (* go: maps.go:11:6 *)
 Definition IterateMapValues : val :=
   rec: "IterateMapValues" "m" :=
-    exception_do (let: "m" := (alloc "m") in
-    let: "sum" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "m" := (mem.alloc "m") in
+    let: "sum" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$range" := (![#(mapT uint64T uint64T)] "m") in
-    (let: "v" := (alloc (type.zero_val #uint64T)) in
+    (let: "v" := (mem.alloc (type.zero_val #uint64T)) in
     map.for_range "$range" (λ: "$key" "value",
       do:  ("v" <-[#uint64T] "$value");;;
       do:  "$key";;;
@@ -1247,10 +1247,10 @@ Definition IterateMapValues : val :=
 (* go: maps.go:19:6 *)
 Definition testIterateMap : val :=
   rec: "testIterateMap" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "m" := (alloc (type.zero_val #(mapT uint64T uint64T))) in
+    let: "m" := (mem.alloc (type.zero_val #(mapT uint64T uint64T))) in
     let: "$r0" := (map.make #uint64T #uint64T) in
     do:  ("m" <-[#(mapT uint64T uint64T)] "$r0");;;
     let: "$r0" := #(W64 1) in
@@ -1270,10 +1270,10 @@ Definition testIterateMap : val :=
 (* go: maps.go:37:6 *)
 Definition testMapSize : val :=
   rec: "testMapSize" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "m" := (alloc (type.zero_val #(mapT uint64T uint64T))) in
+    let: "m" := (mem.alloc (type.zero_val #(mapT uint64T uint64T))) in
     let: "$r0" := (map.make #uint64T #uint64T) in
     do:  ("m" <-[#(mapT uint64T uint64T)] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((s_to_w64 (let: "$a0" := (![#(mapT uint64T uint64T)] "m") in
@@ -1298,10 +1298,10 @@ Definition multReturnTwo : val :=
 (* go: multiple_assign.go:7:6 *)
 Definition testAssignTwo : val :=
   rec: "testAssignTwo" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 10) in
     do:  ("x" <-[#uint64T] "$r0");;;
-    let: "y" := (alloc (type.zero_val #uint64T)) in
+    let: "y" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 15) in
     do:  ("y" <-[#uint64T] "$r0");;;
     let: ("$ret0", "$ret1") := ((func_call #semantics.semantics #"multReturnTwo"%go) #()) in
@@ -1319,13 +1319,13 @@ Definition multReturnThree : val :=
 (* go: multiple_assign.go:18:6 *)
 Definition testAssignThree : val :=
   rec: "testAssignThree" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 10) in
     do:  ("x" <-[#uint64T] "$r0");;;
-    let: "y" := (alloc (type.zero_val #boolT)) in
+    let: "y" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #false in
     do:  ("y" <-[#boolT] "$r0");;;
-    let: "z" := (alloc (type.zero_val #uint32T)) in
+    let: "z" := (mem.alloc (type.zero_val #uint32T)) in
     let: "$r0" := #(W32 15) in
     do:  ("z" <-[#uint32T] "$r0");;;
     let: (("$ret0", "$ret1"), "$ret2") := ((func_call #semantics.semantics #"multReturnThree"%go) #()) in
@@ -1340,10 +1340,10 @@ Definition testAssignThree : val :=
 (* go: multiple_assign.go:26:6 *)
 Definition testMultipleAssignToMap : val :=
   rec: "testMultipleAssignToMap" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 10) in
     do:  ("x" <-[#uint64T] "$r0");;;
-    let: "m" := (alloc (type.zero_val #(mapT uint64T uint64T))) in
+    let: "m" := (mem.alloc (type.zero_val #(mapT uint64T uint64T))) in
     let: "$r0" := (map.make #uint64T #uint64T) in
     do:  ("m" <-[#(mapT uint64T uint64T)] "$r0");;;
     let: ("$ret0", "$ret1") := ((func_call #semantics.semantics #"multReturnTwo"%go) #()) in
@@ -1361,8 +1361,8 @@ Definition returnTwo : val :=
 (* go: multiple_return.go:7:6 *)
 Definition testReturnTwo : val :=
   rec: "testReturnTwo" <> :=
-    exception_do (let: "y" := (alloc (type.zero_val #uint64T)) in
-    let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "y" := (mem.alloc (type.zero_val #uint64T)) in
+    let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: ("$ret0", "$ret1") := ((func_call #semantics.semantics #"returnTwo"%go) #()) in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
@@ -1373,7 +1373,7 @@ Definition testReturnTwo : val :=
 (* go: multiple_return.go:12:6 *)
 Definition testAnonymousBinding : val :=
   rec: "testAnonymousBinding" <> :=
-    exception_do (let: "y" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "y" := (mem.alloc (type.zero_val #uint64T)) in
     let: ("$ret0", "$ret1") := ((func_call #semantics.semantics #"returnTwo"%go) #()) in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
@@ -1389,9 +1389,9 @@ Definition returnThree : val :=
 (* go: multiple_return.go:21:6 *)
 Definition testReturnThree : val :=
   rec: "testReturnThree" <> :=
-    exception_do (let: "z" := (alloc (type.zero_val #uint32T)) in
-    let: "y" := (alloc (type.zero_val #boolT)) in
-    let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "z" := (mem.alloc (type.zero_val #uint32T)) in
+    let: "y" := (mem.alloc (type.zero_val #boolT)) in
+    let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: (("$ret0", "$ret1"), "$ret2") := ((func_call #semantics.semantics #"returnThree"%go) #()) in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
@@ -1409,10 +1409,10 @@ Definition returnFour : val :=
 (* go: multiple_return.go:30:6 *)
 Definition testReturnFour : val :=
   rec: "testReturnFour" <> :=
-    exception_do (let: "w" := (alloc (type.zero_val #uint64T)) in
-    let: "z" := (alloc (type.zero_val #uint32T)) in
-    let: "y" := (alloc (type.zero_val #boolT)) in
-    let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "w" := (mem.alloc (type.zero_val #uint64T)) in
+    let: "z" := (mem.alloc (type.zero_val #uint32T)) in
+    let: "y" := (mem.alloc (type.zero_val #boolT)) in
+    let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: ((("$ret0", "$ret1"), "$ret2"), "$ret3") := ((func_call #semantics.semantics #"returnFour"%go) #()) in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
@@ -1427,7 +1427,7 @@ Definition testReturnFour : val :=
 (* go: nil.go:3:6 *)
 Definition failing_testCompareSliceToNil : val :=
   rec: "failing_testCompareSliceToNil" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 0)) in
     do:  ("s" <-[#sliceT] "$r0");;;
     return: ((![#sliceT] "s") ≠ #slice.nil)).
@@ -1435,23 +1435,23 @@ Definition failing_testCompareSliceToNil : val :=
 (* go: nil.go:8:6 *)
 Definition testComparePointerToNil : val :=
   rec: "testComparePointerToNil" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("s" <-[#ptrT] "$r0");;;
     return: ((![#ptrT] "s") ≠ #null)).
 
 (* go: nil.go:13:6 *)
 Definition testCompareNilToNil : val :=
   rec: "testCompareNilToNil" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #ptrT)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #ptrT)) in
     do:  ("s" <-[#ptrT] "$r0");;;
     return: ((![#ptrT] (![#ptrT] "s")) = #null)).
 
 (* go: nil.go:18:6 *)
 Definition testComparePointerWrappedToNil : val :=
   rec: "testComparePointerWrappedToNil" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 1)) in
     do:  ("s" <-[#sliceT] "$r0");;;
     return: ((![#sliceT] "s") ≠ #slice.nil)).
@@ -1459,7 +1459,7 @@ Definition testComparePointerWrappedToNil : val :=
 (* go: nil.go:24:6 *)
 Definition testComparePointerWrappedDefaultToNil : val :=
   rec: "testComparePointerWrappedDefaultToNil" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #sliceT)) in
     return: ((![#sliceT] "s") = #slice.nil)).
 
 (* helpers
@@ -1467,8 +1467,8 @@ Definition testComparePointerWrappedDefaultToNil : val :=
    go: operations.go:4:6 *)
 Definition reverseAssignOps64 : val :=
   rec: "reverseAssignOps64" "x" :=
-    exception_do (let: "x" := (alloc "x") in
-    let: "y" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc "x") in
+    let: "y" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("y" <-[#uint64T] ((![#uint64T] "y") + (![#uint64T] "x")));;;
     do:  ("y" <-[#uint64T] ((![#uint64T] "y") - (![#uint64T] "x")));;;
     do:  ("y" <-[#uint64T] ((![#uint64T] "y") + #(W64 1)));;;
@@ -1478,8 +1478,8 @@ Definition reverseAssignOps64 : val :=
 (* go: operations.go:13:6 *)
 Definition reverseAssignOps32 : val :=
   rec: "reverseAssignOps32" "x" :=
-    exception_do (let: "x" := (alloc "x") in
-    let: "y" := (alloc (type.zero_val #uint32T)) in
+    exception_do (let: "x" := (mem.alloc "x") in
+    let: "y" := (mem.alloc (type.zero_val #uint32T)) in
     do:  ("y" <-[#uint32T] ((![#uint32T] "y") + (![#uint32T] "x")));;;
     do:  ("y" <-[#uint32T] ((![#uint32T] "y") - (![#uint32T] "x")));;;
     do:  ("y" <-[#uint32T] ((![#uint32T] "y") + #(W32 1)));;;
@@ -1489,17 +1489,17 @@ Definition reverseAssignOps32 : val :=
 (* go: operations.go:22:6 *)
 Definition add64Equals : val :=
   rec: "add64Equals" "x" "y" "z" :=
-    exception_do (let: "z" := (alloc "z") in
-    let: "y" := (alloc "y") in
-    let: "x" := (alloc "x") in
+    exception_do (let: "z" := (mem.alloc "z") in
+    let: "y" := (mem.alloc "y") in
+    let: "x" := (mem.alloc "x") in
     return: (((![#uint64T] "x") + (![#uint64T] "y")) = (![#uint64T] "z"))).
 
 (* go: operations.go:26:6 *)
 Definition sub64Equals : val :=
   rec: "sub64Equals" "x" "y" "z" :=
-    exception_do (let: "z" := (alloc "z") in
-    let: "y" := (alloc "y") in
-    let: "x" := (alloc "x") in
+    exception_do (let: "z" := (mem.alloc "z") in
+    let: "y" := (mem.alloc "y") in
+    let: "x" := (mem.alloc "x") in
     return: (((![#uint64T] "x") - (![#uint64T] "y")) = (![#uint64T] "z"))).
 
 (* tests
@@ -1507,7 +1507,7 @@ Definition sub64Equals : val :=
    go: operations.go:31:6 *)
 Definition testReverseAssignOps64 : val :=
   rec: "testReverseAssignOps64" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((let: "$a0" := #(W64 0) in
@@ -1548,7 +1548,7 @@ Definition testReverseAssignOps64 : val :=
 (* go: operations.go:47:6 *)
 Definition failing_testReverseAssignOps32 : val :=
   rec: "failing_testReverseAssignOps32" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((let: "$a0" := #(W32 0) in
@@ -1583,7 +1583,7 @@ Definition failing_testReverseAssignOps32 : val :=
 (* go: operations.go:61:6 *)
 Definition testAdd64Equals : val :=
   rec: "testAdd64Equals" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && (let: "$a0" := #(W64 2) in
@@ -1601,7 +1601,7 @@ Definition testAdd64Equals : val :=
 (* go: operations.go:68:6 *)
 Definition testSub64Equals : val :=
   rec: "testSub64Equals" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && (let: "$a0" := #(W64 2) in
@@ -1624,13 +1624,13 @@ Definition testSub64Equals : val :=
 (* go: operations.go:76:6 *)
 Definition testDivisionPrecedence : val :=
   rec: "testDivisionPrecedence" <> :=
-    exception_do (let: "blockSize" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "blockSize" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 4096) in
     do:  ("blockSize" <-[#uint64T] "$r0");;;
-    let: "hdrmeta" := (alloc (type.zero_val #uint64T)) in
+    let: "hdrmeta" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 8) in
     do:  ("hdrmeta" <-[#uint64T] "$r0");;;
-    let: "hdraddrs" := (alloc (type.zero_val #uint64T)) in
+    let: "hdraddrs" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (((![#uint64T] "blockSize") - (![#uint64T] "hdrmeta")) `quot` #(W64 8)) in
     do:  ("hdraddrs" <-[#uint64T] "$r0");;;
     return: ((![#uint64T] "hdraddrs") = #(W64 511))).
@@ -1638,10 +1638,10 @@ Definition testDivisionPrecedence : val :=
 (* go: operations.go:83:6 *)
 Definition testModPrecedence : val :=
   rec: "testModPrecedence" <> :=
-    exception_do (let: "x1" := (alloc (type.zero_val #intT)) in
+    exception_do (let: "x1" := (mem.alloc (type.zero_val #intT)) in
     let: "$r0" := #(W64 (513 + (12 `rem` 8))) in
     do:  ("x1" <-[#intT] "$r0");;;
-    let: "x2" := (alloc (type.zero_val #intT)) in
+    let: "x2" := (mem.alloc (type.zero_val #intT)) in
     let: "$r0" := #(W64 ((513 + 12) `rem` 8)) in
     do:  ("x2" <-[#intT] "$r0");;;
     return: (((![#intT] "x1") = #(W64 517)) && ((![#intT] "x2") = #(W64 5)))).
@@ -1649,7 +1649,7 @@ Definition testModPrecedence : val :=
 (* go: operations.go:89:6 *)
 Definition testBitwiseOpsPrecedence : val :=
   rec: "testBitwiseOpsPrecedence" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && #(479 =? 479)) in
@@ -1669,7 +1669,7 @@ Definition testBitwiseOpsPrecedence : val :=
 (* go: operations.go:102:6 *)
 Definition testArithmeticShifts : val :=
   rec: "testArithmeticShifts" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && #(5376 =? 5376)) in
@@ -1687,10 +1687,10 @@ Definition testArithmeticShifts : val :=
 (* go: operations.go:114:6 *)
 Definition testBitAddAnd : val :=
   rec: "testBitAddAnd" <> :=
-    exception_do (let: "tid" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "tid" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 17) in
     do:  ("tid" <-[#uint64T] "$r0");;;
-    let: "n" := (alloc (type.zero_val #uint64T)) in
+    let: "n" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 16) in
     do:  ("n" <-[#uint64T] "$r0");;;
     return: ((((![#uint64T] "tid") + (![#uint64T] "n")) `and` (~ ((![#uint64T] "n") - #(W64 1)))) = #(W64 32))).
@@ -1716,7 +1716,7 @@ Definition testOrCompareSimple : val :=
 (* go: precedence.go:10:6 *)
 Definition testOrCompare : val :=
   rec: "testOrCompare" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     (if: (~ (#(3 >? 4) || #(4 >? 3)))
@@ -1734,7 +1734,7 @@ Definition testOrCompare : val :=
 (* go: precedence.go:22:6 *)
 Definition testAndCompare : val :=
   rec: "testAndCompare" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     (if: #(3 >? 4) && #(4 >? 3)
@@ -1757,8 +1757,8 @@ Definition testShiftMod : val :=
 (* go: prims.go:9:6 *)
 Definition testLinearize : val :=
   rec: "testLinearize" <> :=
-    exception_do (let: "m" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    exception_do (let: "m" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("m" <-[#ptrT] "$r0");;;
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] "m")) #());;;
     do:  ((func_call #primitive #"Linearize"%go) #());;;
@@ -1775,14 +1775,14 @@ Definition BoolTest : go_type := structT [
 (* go: shortcircuiting.go:11:6 *)
 Definition CheckTrue : val :=
   rec: "CheckTrue" "b" :=
-    exception_do (let: "b" := (alloc "b") in
+    exception_do (let: "b" := (mem.alloc "b") in
     do:  ((struct.field_ref #BoolTest #"tc"%go (![#ptrT] "b")) <-[#uint64T] ((![#uint64T] (struct.field_ref #BoolTest #"tc"%go (![#ptrT] "b"))) + #(W64 1)));;;
     return: (![#boolT] (struct.field_ref #BoolTest #"t"%go (![#ptrT] "b")))).
 
 (* go: shortcircuiting.go:16:6 *)
 Definition CheckFalse : val :=
   rec: "CheckFalse" "b" :=
-    exception_do (let: "b" := (alloc "b") in
+    exception_do (let: "b" := (mem.alloc "b") in
     do:  ((struct.field_ref #BoolTest #"fc"%go (![#ptrT] "b")) <-[#uint64T] ((![#uint64T] (struct.field_ref #BoolTest #"fc"%go (![#ptrT] "b"))) + #(W64 1)));;;
     return: (![#boolT] (struct.field_ref #BoolTest #"f"%go (![#ptrT] "b")))).
 
@@ -1791,8 +1791,8 @@ Definition CheckFalse : val :=
    go: shortcircuiting.go:22:6 *)
 Definition testShortcircuitAndTF : val :=
   rec: "testShortcircuitAndTF" <> :=
-    exception_do (let: "b" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (let: "$t" := #true in
+    exception_do (let: "b" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (let: "$t" := #true in
     let: "$f" := #false in
     let: "$tc" := #(W64 0) in
     let: "$fc" := #(W64 0) in
@@ -1813,8 +1813,8 @@ Definition testShortcircuitAndTF : val :=
 (* go: shortcircuiting.go:31:6 *)
 Definition testShortcircuitAndFT : val :=
   rec: "testShortcircuitAndFT" <> :=
-    exception_do (let: "b" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (let: "$t" := #true in
+    exception_do (let: "b" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (let: "$t" := #true in
     let: "$f" := #false in
     let: "$tc" := #(W64 0) in
     let: "$fc" := #(W64 0) in
@@ -1835,8 +1835,8 @@ Definition testShortcircuitAndFT : val :=
 (* go: shortcircuiting.go:40:6 *)
 Definition testShortcircuitOrTF : val :=
   rec: "testShortcircuitOrTF" <> :=
-    exception_do (let: "b" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (let: "$t" := #true in
+    exception_do (let: "b" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (let: "$t" := #true in
     let: "$f" := #false in
     let: "$tc" := #(W64 0) in
     let: "$fc" := #(W64 0) in
@@ -1857,8 +1857,8 @@ Definition testShortcircuitOrTF : val :=
 (* go: shortcircuiting.go:48:6 *)
 Definition testShortcircuitOrFT : val :=
   rec: "testShortcircuitOrFT" <> :=
-    exception_do (let: "b" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (let: "$t" := #true in
+    exception_do (let: "b" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (let: "$t" := #true in
     let: "$f" := #false in
     let: "$tc" := #(W64 0) in
     let: "$fc" := #(W64 0) in
@@ -1884,9 +1884,9 @@ Definition ArrayEditor : go_type := structT [
 (* go: slices.go:9:24 *)
 Definition ArrayEditor__Advance : val :=
   rec: "ArrayEditor__Advance" "ae" "arr" "next" :=
-    exception_do (let: "ae" := (alloc "ae") in
-    let: "next" := (alloc "next") in
-    let: "arr" := (alloc "arr") in
+    exception_do (let: "ae" := (mem.alloc "ae") in
+    let: "next" := (mem.alloc "next") in
+    let: "arr" := (mem.alloc "arr") in
     do:  ((slice.elem_ref #uint64T (![#sliceT] "arr") #(W64 0)) <-[#uint64T] ((![#uint64T] (slice.elem_ref #uint64T (![#sliceT] "arr") #(W64 0))) + #(W64 1)));;;
     let: "$r0" := (![#uint64T] (struct.field_ref #ArrayEditor #"next_val"%go (![#ptrT] "ae"))) in
     do:  ((slice.elem_ref #uint64T (![#sliceT] (struct.field_ref #ArrayEditor #"s"%go (![#ptrT] "ae"))) #(W64 0)) <-[#uint64T] "$r0");;;
@@ -1901,7 +1901,7 @@ Definition ArrayEditor__Advance : val :=
    go: slices.go:17:6 *)
 Definition testSliceOps : val :=
   rec: "testSliceOps" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #uint64T #(W64 10)) in
     do:  ("x" <-[#sliceT] "$r0");;;
     let: "$r0" := #(W64 5) in
@@ -1912,21 +1912,21 @@ Definition testSliceOps : val :=
     do:  ((slice.elem_ref #uint64T (![#sliceT] "x") #(W64 3)) <-[#uint64T] "$r0");;;
     let: "$r0" := #(W64 20) in
     do:  ((slice.elem_ref #uint64T (![#sliceT] "x") #(W64 4)) <-[#uint64T] "$r0");;;
-    let: "v1" := (alloc (type.zero_val #uint64T)) in
+    let: "v1" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (slice.elem_ref #uint64T (![#sliceT] "x") #(W64 2))) in
     do:  ("v1" <-[#uint64T] "$r0");;;
-    let: "v2" := (alloc (type.zero_val #sliceT)) in
+    let: "v2" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$s" := (![#sliceT] "x") in
     slice.slice #uint64T "$s" #(W64 2) #(W64 3)) in
     do:  ("v2" <-[#sliceT] "$r0");;;
-    let: "v3" := (alloc (type.zero_val #sliceT)) in
+    let: "v3" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$s" := (![#sliceT] "x") in
     slice.slice #uint64T "$s" #(W64 0) #(W64 3)) in
     do:  ("v3" <-[#sliceT] "$r0");;;
-    let: "v4" := (alloc (type.zero_val #ptrT)) in
+    let: "v4" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (slice.elem_ref #uint64T (![#sliceT] "x") #(W64 2)) in
     do:  ("v4" <-[#ptrT] "$r0");;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((![#uint64T] "v1") = #(W64 10))) in
@@ -1950,22 +1950,22 @@ Definition testSliceOps : val :=
 (* go: slices.go:40:6 *)
 Definition testSliceCapacityOps : val :=
   rec: "testSliceCapacityOps" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make3 #uint64T #(W64 0) #(W64 10)) in
     do:  ("x" <-[#sliceT] "$r0");;;
-    let: "sub1" := (alloc (type.zero_val #sliceT)) in
+    let: "sub1" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$s" := (![#sliceT] "x") in
     slice.slice #uint64T "$s" #(W64 0) #(W64 6)) in
     do:  ("sub1" <-[#sliceT] "$r0");;;
     let: "$r0" := #(W64 1) in
     do:  ((slice.elem_ref #uint64T (![#sliceT] "sub1") #(W64 0)) <-[#uint64T] "$r0");;;
-    let: "sub2" := (alloc (type.zero_val #sliceT)) in
+    let: "sub2" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$s" := (![#sliceT] "x") in
     slice.slice #uint64T "$s" #(W64 2) #(W64 4)) in
     do:  ("sub2" <-[#sliceT] "$r0");;;
     let: "$r0" := #(W64 2) in
     do:  ((slice.elem_ref #uint64T (![#sliceT] "sub2") #(W64 0)) <-[#uint64T] "$r0");;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((let: "$a0" := (![#sliceT] "sub1") in
@@ -1991,11 +1991,11 @@ Definition testSliceCapacityOps : val :=
 (* go: slices.go:59:6 *)
 Definition testOverwriteArray : val :=
   rec: "testOverwriteArray" <> :=
-    exception_do (let: "arr" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "arr" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #uint64T #(W64 4)) in
     do:  ("arr" <-[#sliceT] "$r0");;;
-    let: "ae1" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (let: "$s" := (let: "$s" := (![#sliceT] "arr") in
+    let: "ae1" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (let: "$s" := (let: "$s" := (![#sliceT] "arr") in
     slice.slice #uint64T "$s" #(W64 0) (slice.len "$s")) in
     let: "$next_val" := #(W64 1) in
     struct.make #ArrayEditor [{
@@ -2003,8 +2003,8 @@ Definition testOverwriteArray : val :=
       "next_val" ::= "$next_val"
     }])) in
     do:  ("ae1" <-[#ptrT] "$r0");;;
-    let: "ae2" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (let: "$s" := (let: "$s" := (![#sliceT] "arr") in
+    let: "ae2" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (let: "$s" := (let: "$s" := (![#sliceT] "arr") in
     slice.slice #uint64T "$s" #(W64 1) (slice.len "$s")) in
     let: "$next_val" := #(W64 102) in
     struct.make #ArrayEditor [{
@@ -2041,17 +2041,17 @@ Definition testOverwriteArray : val :=
 (* go: slices.go:80:6 *)
 Definition testSliceLiteral : val :=
   rec: "testSliceLiteral" <> :=
-    exception_do (let: "bytes" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "bytes" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := ((let: "$sl0" := #(W8 1) in
     let: "$sl1" := #(W8 2) in
     slice.literal #byteT ["$sl0"; "$sl1"])) in
     do:  ("bytes" <-[#sliceT] "$r0");;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((![#byteT] (slice.elem_ref #byteT (![#sliceT] "bytes") #(W64 0))) = #(W8 1))) in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "ints" := (alloc (type.zero_val #sliceT)) in
+    let: "ints" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := ((let: "$sl0" := #(W64 1) in
     let: "$sl1" := #(W64 2) in
     let: "$sl2" := #(W64 3) in
@@ -2064,10 +2064,10 @@ Definition testSliceLiteral : val :=
 (* go: slices.go:89:6 *)
 Definition testSliceAppend : val :=
   rec: "testSliceAppend" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "bytes" := (alloc (type.zero_val #sliceT)) in
+    let: "bytes" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 0)) in
     do:  ("bytes" <-[#sliceT] "$r0");;;
     let: "$r0" := (let: "$a0" := (![#sliceT] "bytes") in
@@ -2075,7 +2075,7 @@ Definition testSliceAppend : val :=
     slice.literal #byteT ["$sl0"])) in
     (slice.append #byteT) "$a0" "$a1") in
     do:  ("bytes" <-[#sliceT] "$r0");;;
-    let: "newBytes" := (alloc (type.zero_val #sliceT)) in
+    let: "newBytes" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := ((let: "$sl0" := #(W8 2) in
     let: "$sl1" := #(W8 3) in
     slice.literal #byteT ["$sl0"; "$sl1"])) in
@@ -2103,7 +2103,7 @@ Definition Foo : go_type := structT [
 (* go: struct_pointers.go:14:17 *)
 Definition Bar__mutate : val :=
   rec: "Bar__mutate" "bar" <> :=
-    exception_do (let: "bar" := (alloc "bar") in
+    exception_do (let: "bar" := (mem.alloc "bar") in
     let: "$r0" := #(W64 2) in
     do:  ((struct.field_ref #Bar #"a"%go (![#ptrT] "bar")) <-[#uint64T] "$r0");;;
     let: "$r0" := #(W64 3) in
@@ -2112,13 +2112,13 @@ Definition Bar__mutate : val :=
 (* go: struct_pointers.go:19:17 *)
 Definition Foo__mutateBar : val :=
   rec: "Foo__mutateBar" "foo" <> :=
-    exception_do (let: "foo" := (alloc "foo") in
+    exception_do (let: "foo" := (mem.alloc "foo") in
     do:  ((method_call #semantics.semantics #"Bar'ptr" #"mutate" (struct.field_ref #Foo #"bar"%go (![#ptrT] "foo"))) #())).
 
 (* go: struct_pointers.go:23:6 *)
 Definition testFooBarMutation : val :=
   rec: "testFooBarMutation" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #Foo)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #Foo)) in
     let: "$r0" := (let: "$bar" := (let: "$a" := #(W64 0) in
     let: "$b" := #(W64 0) in
     struct.make #Bar [{
@@ -2146,7 +2146,7 @@ Definition S : go_type := structT [
 (* go: structs.go:14:6 *)
 Definition NewS : val :=
   rec: "NewS" <> :=
-    exception_do (return: (alloc (let: "$a" := #(W64 2) in
+    exception_do (return: (mem.alloc (let: "$a" := #(W64 2) in
      let: "$b" := (let: "$x" := #(W64 1) in
      let: "$y" := #(W64 2) in
      struct.make #TwoInts [{
@@ -2163,48 +2163,48 @@ Definition NewS : val :=
 (* go: structs.go:22:13 *)
 Definition S__readA : val :=
   rec: "S__readA" "s" <> :=
-    exception_do (let: "s" := (alloc "s") in
+    exception_do (let: "s" := (mem.alloc "s") in
     return: (![#uint64T] (struct.field_ref #S #"a"%go (![#ptrT] "s")))).
 
 (* go: structs.go:26:13 *)
 Definition S__readB : val :=
   rec: "S__readB" "s" <> :=
-    exception_do (let: "s" := (alloc "s") in
+    exception_do (let: "s" := (mem.alloc "s") in
     return: (![#TwoInts] (struct.field_ref #S #"b"%go (![#ptrT] "s")))).
 
 (* go: structs.go:30:12 *)
 Definition S__readBVal : val :=
   rec: "S__readBVal" "s" <> :=
-    exception_do (let: "s" := (alloc "s") in
+    exception_do (let: "s" := (mem.alloc "s") in
     return: (![#TwoInts] (struct.field_ref #S #"b"%go "s"))).
 
 (* go: structs.go:34:13 *)
 Definition S__updateBValX : val :=
   rec: "S__updateBValX" "s" "i" :=
-    exception_do (let: "s" := (alloc "s") in
-    let: "i" := (alloc "i") in
+    exception_do (let: "s" := (mem.alloc "s") in
+    let: "i" := (mem.alloc "i") in
     let: "$r0" := (![#uint64T] "i") in
     do:  ((struct.field_ref #TwoInts #"x"%go (struct.field_ref #S #"b"%go (![#ptrT] "s"))) <-[#uint64T] "$r0")).
 
 (* go: structs.go:38:13 *)
 Definition S__negateC : val :=
   rec: "S__negateC" "s" <> :=
-    exception_do (let: "s" := (alloc "s") in
+    exception_do (let: "s" := (mem.alloc "s") in
     let: "$r0" := (~ (![#boolT] (struct.field_ref #S #"c"%go (![#ptrT] "s")))) in
     do:  ((struct.field_ref #S #"c"%go (![#ptrT] "s")) <-[#boolT] "$r0")).
 
 (* go: structs.go:42:6 *)
 Definition testStructUpdates : val :=
   rec: "testStructUpdates" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "ns" := (alloc (type.zero_val #ptrT)) in
+    let: "ns" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := ((func_call #semantics.semantics #"NewS"%go) #()) in
     do:  ("ns" <-[#ptrT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && (((method_call #semantics.semantics #"S'ptr" #"readA" (![#ptrT] "ns")) #()) = #(W64 2))) in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "b1" := (alloc (type.zero_val #TwoInts)) in
+    let: "b1" := (mem.alloc (type.zero_val #TwoInts)) in
     let: "$r0" := ((method_call #semantics.semantics #"S'ptr" #"readB" (![#ptrT] "ns")) #()) in
     do:  ("b1" <-[#TwoInts] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((![#uint64T] (struct.field_ref #TwoInts #"x"%go "b1")) = #(W64 1))) in
@@ -2214,12 +2214,12 @@ Definition testStructUpdates : val :=
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := #(W64 3) in
     do:  ((struct.field_ref #TwoInts #"x"%go "b1") <-[#uint64T] "$r0");;;
-    let: "b2" := (alloc (type.zero_val #TwoInts)) in
+    let: "b2" := (mem.alloc (type.zero_val #TwoInts)) in
     let: "$r0" := ((method_call #semantics.semantics #"S'ptr" #"readB" (![#ptrT] "ns")) #()) in
     do:  ("b2" <-[#TwoInts] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((![#uint64T] (struct.field_ref #TwoInts #"x"%go "b2")) = #(W64 1))) in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "b3" := (alloc (type.zero_val #ptrT)) in
+    let: "b3" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (struct.field_ref #S #"b"%go (![#ptrT] "ns")) in
     do:  ("b3" <-[#ptrT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((![#uint64T] (struct.field_ref #TwoInts #"x"%go (![#ptrT] "b3"))) = #(W64 1))) in
@@ -2233,10 +2233,10 @@ Definition testStructUpdates : val :=
 (* go: structs.go:65:6 *)
 Definition testNestedStructUpdates : val :=
   rec: "testNestedStructUpdates" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "ns" := (alloc (type.zero_val #ptrT)) in
+    let: "ns" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := ((func_call #semantics.semantics #"NewS"%go) #()) in
     do:  ("ns" <-[#ptrT] "$r0");;;
     let: "$r0" := #(W64 5) in
@@ -2245,7 +2245,7 @@ Definition testNestedStructUpdates : val :=
     do:  ("ok" <-[#boolT] "$r0");;;
     let: "$r0" := ((func_call #semantics.semantics #"NewS"%go) #()) in
     do:  ("ns" <-[#ptrT] "$r0");;;
-    let: "p" := (alloc (type.zero_val #ptrT)) in
+    let: "p" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (struct.field_ref #S #"b"%go (![#ptrT] "ns")) in
     do:  ("p" <-[#ptrT] "$r0");;;
     let: "$r0" := #(W64 5) in
@@ -2273,12 +2273,12 @@ Definition testNestedStructUpdates : val :=
 (* go: structs.go:90:6 *)
 Definition testStructConstructions : val :=
   rec: "testStructConstructions" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "p1" := (alloc (type.zero_val #ptrT)) in
-    let: "p2" := (alloc (type.zero_val #TwoInts)) in
-    let: "p3" := (alloc (type.zero_val #TwoInts)) in
+    let: "p1" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "p2" := (mem.alloc (type.zero_val #TwoInts)) in
+    let: "p3" := (mem.alloc (type.zero_val #TwoInts)) in
     let: "$r0" := (let: "$y" := #(W64 0) in
     let: "$x" := #(W64 0) in
     struct.make #TwoInts [{
@@ -2286,7 +2286,7 @@ Definition testStructConstructions : val :=
       "y" ::= "$y"
     }]) in
     do:  ("p3" <-[#TwoInts] "$r0");;;
-    let: "p4" := (alloc (type.zero_val #TwoInts)) in
+    let: "p4" := (mem.alloc (type.zero_val #TwoInts)) in
     let: "$r0" := (let: "$x" := #(W64 0) in
     let: "$y" := #(W64 0) in
     struct.make #TwoInts [{
@@ -2296,7 +2296,7 @@ Definition testStructConstructions : val :=
     do:  ("p4" <-[#TwoInts] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((![#ptrT] "p1") = #null)) in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "$r0" := (alloc (type.zero_val #TwoInts)) in
+    let: "$r0" := (mem.alloc (type.zero_val #TwoInts)) in
     do:  ("p1" <-[#ptrT] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((![#TwoInts] "p2") = (![#TwoInts] "p3"))) in
     do:  ("ok" <-[#boolT] "$r0");;;
@@ -2311,10 +2311,10 @@ Definition testStructConstructions : val :=
 (* go: structs.go:109:6 *)
 Definition testIncompleteStruct : val :=
   rec: "testIncompleteStruct" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "p1" := (alloc (type.zero_val #TwoInts)) in
+    let: "p1" := (mem.alloc (type.zero_val #TwoInts)) in
     let: "$r0" := (let: "$x" := #(W64 0) in
     struct.make #TwoInts [{
       "x" ::= "$x";
@@ -2323,7 +2323,7 @@ Definition testIncompleteStruct : val :=
     do:  ("p1" <-[#TwoInts] "$r0");;;
     let: "$r0" := ((![#boolT] "ok") && ((![#uint64T] (struct.field_ref #TwoInts #"y"%go "p1")) = #(W64 0))) in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "p2" := (alloc (type.zero_val #S)) in
+    let: "p2" := (mem.alloc (type.zero_val #S)) in
     let: "$r0" := (let: "$a" := #(W64 2) in
     struct.make #S [{
       "a" ::= "$a";
@@ -2344,7 +2344,7 @@ Definition StructWrap : go_type := structT [
 (* go: structs.go:126:6 *)
 Definition testStoreInStructVar : val :=
   rec: "testStoreInStructVar" <> :=
-    exception_do (let: "p" := (alloc (type.zero_val #StructWrap)) in
+    exception_do (let: "p" := (mem.alloc (type.zero_val #StructWrap)) in
     let: "$r0" := (let: "$i" := #(W64 0) in
     struct.make #StructWrap [{
       "i" ::= "$i"
@@ -2357,8 +2357,8 @@ Definition testStoreInStructVar : val :=
 (* go: structs.go:132:6 *)
 Definition testStoreInStructPointerVar : val :=
   rec: "testStoreInStructPointerVar" <> :=
-    exception_do (let: "p" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #StructWrap)) in
+    exception_do (let: "p" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #StructWrap)) in
     do:  ("p" <-[#ptrT] "$r0");;;
     let: "$r0" := #(W64 5) in
     do:  ((struct.field_ref #StructWrap #"i"%go (![#ptrT] "p")) <-[#uint64T] "$r0");;;
@@ -2367,8 +2367,8 @@ Definition testStoreInStructPointerVar : val :=
 (* go: structs.go:138:6 *)
 Definition testStoreComposite : val :=
   rec: "testStoreComposite" <> :=
-    exception_do (let: "p" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #TwoInts)) in
+    exception_do (let: "p" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #TwoInts)) in
     do:  ("p" <-[#ptrT] "$r0");;;
     let: "$r0" := (let: "$x" := #(W64 3) in
     let: "$y" := #(W64 4) in
@@ -2382,10 +2382,10 @@ Definition testStoreComposite : val :=
 (* go: structs.go:144:6 *)
 Definition testStoreSlice : val :=
   rec: "testStoreSlice" <> :=
-    exception_do (let: "p" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "p" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sliceT)) in
     do:  ("p" <-[#ptrT] "$r0");;;
-    let: "s" := (alloc (type.zero_val #sliceT)) in
+    let: "s" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #uint64T #(W64 3)) in
     do:  ("s" <-[#sliceT] "$r0");;;
     let: "$r0" := (![#sliceT] "s") in
@@ -2400,11 +2400,11 @@ Definition StructWithFunc : go_type := structT [
 (* go: structs.go:155:6 *)
 Definition testStructFieldFunc : val :=
   rec: "testStructFieldFunc" <> :=
-    exception_do (let: "a" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #StructWithFunc)) in
+    exception_do (let: "a" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #StructWithFunc)) in
     do:  ("a" <-[#ptrT] "$r0");;;
     let: "$r0" := (λ: "arg",
-      exception_do (let: "arg" := (alloc "arg") in
+      exception_do (let: "arg" := (mem.alloc "arg") in
       return: ((![#uint64T] "arg") * #(W64 2)))
       ) in
     do:  ((struct.field_ref #StructWithFunc #"fn"%go (![#ptrT] "a")) <-[#funcT] "$r0");;;
@@ -2414,7 +2414,7 @@ Definition testStructFieldFunc : val :=
 (* go: switch.go:3:6 *)
 Definition testSwitchVal : val :=
   rec: "testSwitchVal" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("x" <-[#uint64T] "$r0");;;
     let: "$sw" := (![#uint64T] "x") in
@@ -2428,7 +2428,7 @@ Definition testSwitchVal : val :=
 (* go: switch.go:15:6 *)
 Definition testSwitchMultiple : val :=
   rec: "testSwitchMultiple" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("x" <-[#uint64T] "$r0");;;
     let: "$sw" := (![#uint64T] "x") in
@@ -2443,7 +2443,7 @@ Definition testSwitchMultiple : val :=
 (* go: switch.go:26:6 *)
 Definition testSwitchDefaultTrue : val :=
   rec: "testSwitchDefaultTrue" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 1) in
     do:  ("x" <-[#uint64T] "$r0");;;
     let: "$sw" := #true in
@@ -2462,17 +2462,17 @@ Definition switchInterface : go_type := interfaceT.
 (* go: switch.go:45:26 *)
 Definition switchConcrete__marker : val :=
   rec: "switchConcrete__marker" "c" <> :=
-    exception_do (let: "c" := (alloc "c") in
+    exception_do (let: "c" := (mem.alloc "c") in
     do:  #()).
 
 (* go: switch.go:48:6 *)
 Definition testSwitchConversion : val :=
   rec: "testSwitchConversion" <> :=
-    exception_do (let: "v" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (struct.make #switchConcrete [{
+    exception_do (let: "v" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (struct.make #switchConcrete [{
     }])) in
     do:  ("v" <-[#ptrT] "$r0");;;
-    let: "x" := (alloc (type.zero_val #switchInterface)) in
+    let: "x" := (mem.alloc (type.zero_val #switchInterface)) in
     let: "$r0" := (interface.make #semantics.semantics #"switchConcrete'ptr" (![#ptrT] "v")) in
     do:  ("x" <-[#switchInterface] "$r0");;;
     let: "$sw" := (![#switchInterface] "x") in
@@ -2488,7 +2488,7 @@ Definition testSwitchConversion : val :=
 (* go: vars.go:3:6 *)
 Definition testPointerAssignment : val :=
   rec: "testPointerAssignment" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("x" <-[#boolT] "$r0");;;
     return: (![#boolT] "x")).
@@ -2496,10 +2496,10 @@ Definition testPointerAssignment : val :=
 (* go: vars.go:9:6 *)
 Definition testAddressOfLocal : val :=
   rec: "testAddressOfLocal" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #false in
     do:  ("x" <-[#boolT] "$r0");;;
-    let: "xptr" := (alloc (type.zero_val #ptrT)) in
+    let: "xptr" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := "x" in
     do:  ("xptr" <-[#ptrT] "$r0");;;
     let: "$r0" := #true in
@@ -2528,8 +2528,8 @@ Definition Log : go_type := structT [
 (* go: wal.go:25:6 *)
 Definition intToBlock : val :=
   rec: "intToBlock" "a" :=
-    exception_do (let: "a" := (alloc "a") in
-    let: "b" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "a" := (mem.alloc "a") in
+    let: "b" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT disk.BlockSize) in
     do:  ("b" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := (![#sliceT] "b") in
@@ -2540,8 +2540,8 @@ Definition intToBlock : val :=
 (* go: wal.go:31:6 *)
 Definition blockToInt : val :=
   rec: "blockToInt" "v" :=
-    exception_do (let: "v" := (alloc "v") in
-    let: "a" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "v" := (mem.alloc "v") in
+    let: "a" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "v") in
     (func_call #primitive #"UInt64Get"%go) "$a0") in
     do:  ("a" <-[#uint64T] "$r0");;;
@@ -2552,10 +2552,10 @@ Definition blockToInt : val :=
    go: wal.go:37:6 *)
 Definition New : val :=
   rec: "New" <> :=
-    exception_do (let: "d" := (alloc (type.zero_val #disk.Disk)) in
+    exception_do (let: "d" := (mem.alloc (type.zero_val #disk.Disk)) in
     let: "$r0" := ((func_call #disk #"Get"%go) #()) in
     do:  ("d" <-[#disk.Disk] "$r0");;;
-    let: "diskSize" := (alloc (type.zero_val #uint64T)) in
+    let: "diskSize" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := ((interface.get #"Size"%go (![#disk.Disk] "d")) #()) in
     do:  ("diskSize" <-[#uint64T] "$r0");;;
     (if: (![#uint64T] "diskSize") ≤ logLength
@@ -2563,23 +2563,23 @@ Definition New : val :=
       do:  (let: "$a0" := (interface.make #""%go #"string"%go #"disk is too small to host log"%go) in
       Panic "$a0")
     else do:  #());;;
-    let: "cache" := (alloc (type.zero_val #(mapT uint64T sliceT))) in
+    let: "cache" := (mem.alloc (type.zero_val #(mapT uint64T sliceT))) in
     let: "$r0" := (map.make #uint64T #sliceT) in
     do:  ("cache" <-[#(mapT uint64T sliceT)] "$r0");;;
-    let: "header" := (alloc (type.zero_val #sliceT)) in
+    let: "header" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
     (func_call #semantics.semantics #"intToBlock"%go) "$a0") in
     do:  ("header" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := #(W64 0) in
     let: "$a1" := (![#sliceT] "header") in
     (interface.get #"Write"%go (![#disk.Disk] "d")) "$a0" "$a1");;;
-    let: "lengthPtr" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #uint64T)) in
+    let: "lengthPtr" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("lengthPtr" <-[#ptrT] "$r0");;;
     let: "$r0" := #(W64 0) in
     do:  ((![#ptrT] "lengthPtr") <-[#uint64T] "$r0");;;
-    let: "l" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    let: "l" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("l" <-[#ptrT] "$r0");;;
     return: (let: "$d" := (![#disk.Disk] "d") in
      let: "$cache" := (![#(mapT uint64T sliceT)] "cache") in
@@ -2595,13 +2595,13 @@ Definition New : val :=
 (* go: wal.go:52:14 *)
 Definition Log__lock : val :=
   rec: "Log__lock" "l" <> :=
-    exception_do (let: "l" := (alloc "l") in
+    exception_do (let: "l" := (mem.alloc "l") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"l"%go "l"))) #())).
 
 (* go: wal.go:56:14 *)
 Definition Log__unlock : val :=
   rec: "Log__unlock" "l" <> :=
-    exception_do (let: "l" := (alloc "l") in
+    exception_do (let: "l" := (mem.alloc "l") in
     do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Log #"l"%go "l"))) #())).
 
 (* BeginTxn allocates space for a new transaction in the log.
@@ -2611,9 +2611,9 @@ Definition Log__unlock : val :=
    go: wal.go:63:14 *)
 Definition Log__BeginTxn : val :=
   rec: "Log__BeginTxn" "l" <> :=
-    exception_do (let: "l" := (alloc "l") in
+    exception_do (let: "l" := (mem.alloc "l") in
     do:  ((method_call #semantics.semantics #"Log" #"lock" (![#Log] "l")) #());;;
-    let: "length" := (alloc (type.zero_val #uint64T)) in
+    let: "length" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] (struct.field_ref #Log #"length"%go "l"))) in
     do:  ("length" <-[#uint64T] "$r0");;;
     (if: (![#uint64T] "length") = #(W64 0)
@@ -2631,11 +2631,11 @@ Definition Log__BeginTxn : val :=
    go: wal.go:77:14 *)
 Definition Log__Read : val :=
   rec: "Log__Read" "l" "a" :=
-    exception_do (let: "l" := (alloc "l") in
-    let: "a" := (alloc "a") in
+    exception_do (let: "l" := (mem.alloc "l") in
+    let: "a" := (mem.alloc "a") in
     do:  ((method_call #semantics.semantics #"Log" #"lock" (![#Log] "l")) #());;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
-    let: "v" := (alloc (type.zero_val #sliceT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
+    let: "v" := (mem.alloc (type.zero_val #sliceT)) in
     let: ("$ret0", "$ret1") := (map.get (![#(mapT uint64T sliceT)] (struct.field_ref #Log #"cache"%go "l")) (![#uint64T] "a")) in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
@@ -2647,7 +2647,7 @@ Definition Log__Read : val :=
       return: (![#sliceT] "v")
     else do:  #());;;
     do:  ((method_call #semantics.semantics #"Log" #"unlock" (![#Log] "l")) #());;;
-    let: "dv" := (alloc (type.zero_val #sliceT)) in
+    let: "dv" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (logLength + (![#uint64T] "a")) in
     (interface.get #"Read"%go (![#disk.Disk] (struct.field_ref #Log #"d"%go "l"))) "$a0") in
     do:  ("dv" <-[#sliceT] "$r0");;;
@@ -2656,8 +2656,8 @@ Definition Log__Read : val :=
 (* go: wal.go:90:14 *)
 Definition Log__Size : val :=
   rec: "Log__Size" "l" <> :=
-    exception_do (let: "l" := (alloc "l") in
-    let: "sz" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "l" := (mem.alloc "l") in
+    let: "sz" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := ((interface.get #"Size"%go (![#disk.Disk] (struct.field_ref #Log #"d"%go "l"))) #()) in
     do:  ("sz" <-[#uint64T] "$r0");;;
     return: ((![#uint64T] "sz") - logLength)).
@@ -2667,11 +2667,11 @@ Definition Log__Size : val :=
    go: wal.go:97:14 *)
 Definition Log__Write : val :=
   rec: "Log__Write" "l" "a" "v" :=
-    exception_do (let: "l" := (alloc "l") in
-    let: "v" := (alloc "v") in
-    let: "a" := (alloc "a") in
+    exception_do (let: "l" := (mem.alloc "l") in
+    let: "v" := (mem.alloc "v") in
+    let: "a" := (mem.alloc "a") in
     do:  ((method_call #semantics.semantics #"Log" #"lock" (![#Log] "l")) #());;;
-    let: "length" := (alloc (type.zero_val #uint64T)) in
+    let: "length" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] (struct.field_ref #Log #"length"%go "l"))) in
     do:  ("length" <-[#uint64T] "$r0");;;
     (if: (![#uint64T] "length") ≥ MaxTxnWrites
@@ -2679,11 +2679,11 @@ Definition Log__Write : val :=
       do:  (let: "$a0" := (interface.make #""%go #"string"%go #"transaction is at capacity"%go) in
       Panic "$a0")
     else do:  #());;;
-    let: "aBlock" := (alloc (type.zero_val #sliceT)) in
+    let: "aBlock" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#uint64T] "a") in
     (func_call #semantics.semantics #"intToBlock"%go) "$a0") in
     do:  ("aBlock" <-[#sliceT] "$r0");;;
-    let: "nextAddr" := (alloc (type.zero_val #uint64T)) in
+    let: "nextAddr" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (#(W64 1) + (#(W64 2) * (![#uint64T] "length"))) in
     do:  ("nextAddr" <-[#uint64T] "$r0");;;
     do:  (let: "$a0" := (![#uint64T] "nextAddr") in
@@ -2703,13 +2703,13 @@ Definition Log__Write : val :=
    go: wal.go:113:14 *)
 Definition Log__Commit : val :=
   rec: "Log__Commit" "l" <> :=
-    exception_do (let: "l" := (alloc "l") in
+    exception_do (let: "l" := (mem.alloc "l") in
     do:  ((method_call #semantics.semantics #"Log" #"lock" (![#Log] "l")) #());;;
-    let: "length" := (alloc (type.zero_val #uint64T)) in
+    let: "length" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] (struct.field_ref #Log #"length"%go "l"))) in
     do:  ("length" <-[#uint64T] "$r0");;;
     do:  ((method_call #semantics.semantics #"Log" #"unlock" (![#Log] "l")) #());;;
-    let: "header" := (alloc (type.zero_val #sliceT)) in
+    let: "header" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#uint64T] "length") in
     (func_call #semantics.semantics #"intToBlock"%go) "$a0") in
     do:  ("header" <-[#sliceT] "$r0");;;
@@ -2720,20 +2720,20 @@ Definition Log__Commit : val :=
 (* go: wal.go:122:6 *)
 Definition getLogEntry : val :=
   rec: "getLogEntry" "d" "logOffset" :=
-    exception_do (let: "logOffset" := (alloc "logOffset") in
-    let: "d" := (alloc "d") in
-    let: "diskAddr" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "logOffset" := (mem.alloc "logOffset") in
+    let: "d" := (mem.alloc "d") in
+    let: "diskAddr" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (#(W64 1) + (#(W64 2) * (![#uint64T] "logOffset"))) in
     do:  ("diskAddr" <-[#uint64T] "$r0");;;
-    let: "aBlock" := (alloc (type.zero_val #sliceT)) in
+    let: "aBlock" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#uint64T] "diskAddr") in
     (interface.get #"Read"%go (![#disk.Disk] "d")) "$a0") in
     do:  ("aBlock" <-[#sliceT] "$r0");;;
-    let: "a" := (alloc (type.zero_val #uint64T)) in
+    let: "a" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "aBlock") in
     (func_call #semantics.semantics #"blockToInt"%go) "$a0") in
     do:  ("a" <-[#uint64T] "$r0");;;
-    let: "v" := (alloc (type.zero_val #sliceT)) in
+    let: "v" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := ((![#uint64T] "diskAddr") + #(W64 1)) in
     (interface.get #"Read"%go (![#disk.Disk] "d")) "$a0") in
     do:  ("v" <-[#sliceT] "$r0");;;
@@ -2744,16 +2744,16 @@ Definition getLogEntry : val :=
    go: wal.go:131:6 *)
 Definition applyLog : val :=
   rec: "applyLog" "d" "length" :=
-    exception_do (let: "length" := (alloc "length") in
-    let: "d" := (alloc "d") in
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "length" := (mem.alloc "length") in
+    let: "d" := (mem.alloc "d") in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
       (if: (![#uint64T] "i") < (![#uint64T] "length")
       then
-        let: "v" := (alloc (type.zero_val #sliceT)) in
-        let: "a" := (alloc (type.zero_val #uint64T)) in
+        let: "v" := (mem.alloc (type.zero_val #sliceT)) in
+        let: "a" := (mem.alloc (type.zero_val #uint64T)) in
         let: ("$ret0", "$ret1") := (let: "$a0" := (![#disk.Disk] "d") in
         let: "$a1" := (![#uint64T] "i") in
         (func_call #semantics.semantics #"getLogEntry"%go) "$a0" "$a1") in
@@ -2773,8 +2773,8 @@ Definition applyLog : val :=
 (* go: wal.go:142:6 *)
 Definition clearLog : val :=
   rec: "clearLog" "d" :=
-    exception_do (let: "d" := (alloc "d") in
-    let: "header" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "d" := (mem.alloc "d") in
+    let: "header" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
     (func_call #semantics.semantics #"intToBlock"%go) "$a0") in
     do:  ("header" <-[#sliceT] "$r0");;;
@@ -2789,9 +2789,9 @@ Definition clearLog : val :=
    go: wal.go:150:14 *)
 Definition Log__Apply : val :=
   rec: "Log__Apply" "l" <> :=
-    exception_do (let: "l" := (alloc "l") in
+    exception_do (let: "l" := (mem.alloc "l") in
     do:  ((method_call #semantics.semantics #"Log" #"lock" (![#Log] "l")) #());;;
-    let: "length" := (alloc (type.zero_val #uint64T)) in
+    let: "length" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] (struct.field_ref #Log #"length"%go "l"))) in
     do:  ("length" <-[#uint64T] "$r0");;;
     do:  (let: "$a0" := (![#disk.Disk] (struct.field_ref #Log #"d"%go "l")) in
@@ -2808,14 +2808,14 @@ Definition Log__Apply : val :=
    go: wal.go:163:6 *)
 Definition Open : val :=
   rec: "Open" <> :=
-    exception_do (let: "d" := (alloc (type.zero_val #disk.Disk)) in
+    exception_do (let: "d" := (mem.alloc (type.zero_val #disk.Disk)) in
     let: "$r0" := ((func_call #disk #"Get"%go) #()) in
     do:  ("d" <-[#disk.Disk] "$r0");;;
-    let: "header" := (alloc (type.zero_val #sliceT)) in
+    let: "header" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
     (interface.get #"Read"%go (![#disk.Disk] "d")) "$a0") in
     do:  ("header" <-[#sliceT] "$r0");;;
-    let: "length" := (alloc (type.zero_val #uint64T)) in
+    let: "length" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "header") in
     (func_call #semantics.semantics #"blockToInt"%go) "$a0") in
     do:  ("length" <-[#uint64T] "$r0");;;
@@ -2824,16 +2824,16 @@ Definition Open : val :=
     (func_call #semantics.semantics #"applyLog"%go) "$a0" "$a1");;;
     do:  (let: "$a0" := (![#disk.Disk] "d") in
     (func_call #semantics.semantics #"clearLog"%go) "$a0");;;
-    let: "cache" := (alloc (type.zero_val #(mapT uint64T sliceT))) in
+    let: "cache" := (mem.alloc (type.zero_val #(mapT uint64T sliceT))) in
     let: "$r0" := (map.make #uint64T #sliceT) in
     do:  ("cache" <-[#(mapT uint64T sliceT)] "$r0");;;
-    let: "lengthPtr" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #uint64T)) in
+    let: "lengthPtr" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("lengthPtr" <-[#ptrT] "$r0");;;
     let: "$r0" := #(W64 0) in
     do:  ((![#ptrT] "lengthPtr") <-[#uint64T] "$r0");;;
-    let: "l" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    let: "l" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("l" <-[#ptrT] "$r0");;;
     return: (let: "$d" := (![#disk.Disk] "d") in
      let: "$cache" := (![#(mapT uint64T sliceT)] "cache") in
@@ -2851,10 +2851,10 @@ Definition Open : val :=
    go: wal.go:178:6 *)
 Definition disabled_testWal : val :=
   rec: "disabled_testWal" <> :=
-    exception_do (let: "ok" := (alloc (type.zero_val #boolT)) in
+    exception_do (let: "ok" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("ok" <-[#boolT] "$r0");;;
-    let: "lg" := (alloc (type.zero_val #Log)) in
+    let: "lg" := (mem.alloc (type.zero_val #Log)) in
     let: "$r0" := ((func_call #semantics.semantics #"New"%go) #()) in
     do:  ("lg" <-[#Log] "$r0");;;
     (if: (method_call #semantics.semantics #"Log" #"BeginTxn" (![#Log] "lg")) #()

--- a/testdata/examples/simpledb/simpledb.gold.v
+++ b/testdata/examples/simpledb/simpledb.gold.v
@@ -28,11 +28,11 @@ Definition Table : go_type := structT [
    go: simpledb.go:32:6 *)
 Definition CreateTable : val :=
   rec: "CreateTable" "p" :=
-    exception_do (let: "p" := (alloc "p") in
-    let: "index" := (alloc (type.zero_val #(mapT uint64T uint64T))) in
+    exception_do (let: "p" := (mem.alloc "p") in
+    let: "index" := (mem.alloc (type.zero_val #(mapT uint64T uint64T))) in
     let: "$r0" := (map.make #uint64T #uint64T) in
     do:  ("index" <-[#(mapT uint64T uint64T)] "$r0");;;
-    let: "f" := (alloc (type.zero_val #fileT)) in
+    let: "f" := (mem.alloc (type.zero_val #fileT)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := #"db"%go in
     let: "$a1" := (![#stringT] "p") in
     (func_call #filesys #"Create"%go) "$a0" "$a1") in
@@ -42,7 +42,7 @@ Definition CreateTable : val :=
     do:  "$r1";;;
     do:  (let: "$a0" := (![#fileT] "f") in
     (func_call #filesys #"Close"%go) "$a0");;;
-    let: "f2" := (alloc (type.zero_val #fileT)) in
+    let: "f2" := (mem.alloc (type.zero_val #fileT)) in
     let: "$r0" := (let: "$a0" := #"db"%go in
     let: "$a1" := (![#stringT] "p") in
     (func_call #filesys #"Open"%go) "$a0" "$a1") in
@@ -69,12 +69,12 @@ Definition Entry : go_type := structT [
    go: simpledb.go:52:6 *)
 Definition DecodeUInt64 : val :=
   rec: "DecodeUInt64" "p" :=
-    exception_do (let: "p" := (alloc "p") in
+    exception_do (let: "p" := (mem.alloc "p") in
     (if: int_lt (let: "$a0" := (![#sliceT] "p") in
     slice.len "$a0") #(W64 8)
     then return: (#(W64 0), #(W64 0))
     else do:  #());;;
-    let: "n" := (alloc (type.zero_val #uint64T)) in
+    let: "n" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "p") in
     (func_call #primitive #"UInt64Get"%go) "$a0") in
     do:  ("n" <-[#uint64T] "$r0");;;
@@ -85,9 +85,9 @@ Definition DecodeUInt64 : val :=
    go: simpledb.go:61:6 *)
 Definition DecodeEntry : val :=
   rec: "DecodeEntry" "data" :=
-    exception_do (let: "data" := (alloc "data") in
-    let: "l1" := (alloc (type.zero_val #uint64T)) in
-    let: "key" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "data" := (mem.alloc "data") in
+    let: "l1" := (mem.alloc (type.zero_val #uint64T)) in
+    let: "key" := (mem.alloc (type.zero_val #uint64T)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := (![#sliceT] "data") in
     (func_call #simpledb.simpledb #"DecodeUInt64"%go) "$a0") in
     let: "$r0" := "$ret0" in
@@ -103,8 +103,8 @@ Definition DecodeEntry : val :=
          "Value" ::= "$Value"
        }], #(W64 0))
     else do:  #());;;
-    let: "l2" := (alloc (type.zero_val #uint64T)) in
-    let: "valueLen" := (alloc (type.zero_val #uint64T)) in
+    let: "l2" := (mem.alloc (type.zero_val #uint64T)) in
+    let: "valueLen" := (mem.alloc (type.zero_val #uint64T)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := (let: "$s" := (![#sliceT] "data") in
     slice.slice #byteT "$s" (![#uint64T] "l1") (slice.len "$s")) in
     (func_call #simpledb.simpledb #"DecodeUInt64"%go) "$a0") in
@@ -131,7 +131,7 @@ Definition DecodeEntry : val :=
          "Value" ::= "$Value"
        }], #(W64 0))
     else do:  #());;;
-    let: "value" := (alloc (type.zero_val #sliceT)) in
+    let: "value" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$s" := (![#sliceT] "data") in
     slice.slice #byteT "$s" ((![#uint64T] "l1") + (![#uint64T] "l2")) (((![#uint64T] "l1") + (![#uint64T] "l2")) + (![#uint64T] "valueLen"))) in
     do:  ("value" <-[#sliceT] "$r0");;;
@@ -152,9 +152,9 @@ Definition lazyFileBuf : go_type := structT [
    go: simpledb.go:86:6 *)
 Definition readTableIndex : val :=
   rec: "readTableIndex" "f" "index" :=
-    exception_do (let: "index" := (alloc "index") in
-    let: "f" := (alloc "f") in
-    (let: "buf" := (alloc (type.zero_val #lazyFileBuf)) in
+    exception_do (let: "index" := (mem.alloc "index") in
+    let: "f" := (mem.alloc "f") in
+    (let: "buf" := (mem.alloc (type.zero_val #lazyFileBuf)) in
     let: "$r0" := (let: "$offset" := #(W64 0) in
     let: "$next" := #slice.nil in
     struct.make #lazyFileBuf [{
@@ -163,8 +163,8 @@ Definition readTableIndex : val :=
     }]) in
     do:  ("buf" <-[#lazyFileBuf] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
-      let: "l" := (alloc (type.zero_val #uint64T)) in
-      let: "e" := (alloc (type.zero_val #Entry)) in
+      let: "l" := (mem.alloc (type.zero_val #uint64T)) in
+      let: "e" := (mem.alloc (type.zero_val #Entry)) in
       let: ("$ret0", "$ret1") := (let: "$a0" := (![#sliceT] (struct.field_ref #lazyFileBuf #"next"%go "buf")) in
       (func_call #simpledb.simpledb #"DecodeEntry"%go) "$a0") in
       let: "$r0" := "$ret0" in
@@ -185,7 +185,7 @@ Definition readTableIndex : val :=
         do:  ("buf" <-[#lazyFileBuf] "$r0");;;
         continue: #()
       else
-        let: "p" := (alloc (type.zero_val #sliceT)) in
+        let: "p" := (mem.alloc (type.zero_val #sliceT)) in
         let: "$r0" := (let: "$a0" := (![#fileT] "f") in
         let: "$a1" := ((![#uint64T] (struct.field_ref #lazyFileBuf #"offset"%go "buf")) + (s_to_w64 (let: "$a0" := (![#sliceT] (struct.field_ref #lazyFileBuf #"next"%go "buf")) in
         slice.len "$a0"))) in
@@ -196,7 +196,7 @@ Definition readTableIndex : val :=
         slice.len "$a0") = #(W64 0)
         then break: #()
         else
-          let: "newBuf" := (alloc (type.zero_val #sliceT)) in
+          let: "newBuf" := (mem.alloc (type.zero_val #sliceT)) in
           let: "$r0" := (let: "$a0" := (![#sliceT] (struct.field_ref #lazyFileBuf #"next"%go "buf")) in
           let: "$a1" := (![#sliceT] "p") in
           (slice.append #byteT) "$a0" "$a1") in
@@ -215,11 +215,11 @@ Definition readTableIndex : val :=
    go: simpledb.go:111:6 *)
 Definition RecoverTable : val :=
   rec: "RecoverTable" "p" :=
-    exception_do (let: "p" := (alloc "p") in
-    let: "index" := (alloc (type.zero_val #(mapT uint64T uint64T))) in
+    exception_do (let: "p" := (mem.alloc "p") in
+    let: "index" := (mem.alloc (type.zero_val #(mapT uint64T uint64T))) in
     let: "$r0" := (map.make #uint64T #uint64T) in
     do:  ("index" <-[#(mapT uint64T uint64T)] "$r0");;;
-    let: "f" := (alloc (type.zero_val #fileT)) in
+    let: "f" := (mem.alloc (type.zero_val #fileT)) in
     let: "$r0" := (let: "$a0" := #"db"%go in
     let: "$a1" := (![#stringT] "p") in
     (func_call #filesys #"Open"%go) "$a0" "$a1") in
@@ -239,42 +239,42 @@ Definition RecoverTable : val :=
    go: simpledb.go:119:6 *)
 Definition CloseTable : val :=
   rec: "CloseTable" "t" :=
-    exception_do (let: "t" := (alloc "t") in
+    exception_do (let: "t" := (mem.alloc "t") in
     do:  (let: "$a0" := (![#fileT] (struct.field_ref #Table #"File"%go "t")) in
     (func_call #filesys #"Close"%go) "$a0")).
 
 (* go: simpledb.go:123:6 *)
 Definition readValue : val :=
   rec: "readValue" "f" "off" :=
-    exception_do (let: "off" := (alloc "off") in
-    let: "f" := (alloc "f") in
-    let: "startBuf" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "off" := (mem.alloc "off") in
+    let: "f" := (mem.alloc "f") in
+    let: "startBuf" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#fileT] "f") in
     let: "$a1" := (![#uint64T] "off") in
     let: "$a2" := #(W64 512) in
     (func_call #filesys #"ReadAt"%go) "$a0" "$a1" "$a2") in
     do:  ("startBuf" <-[#sliceT] "$r0");;;
-    let: "totalBytes" := (alloc (type.zero_val #uint64T)) in
+    let: "totalBytes" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "startBuf") in
     (func_call #primitive #"UInt64Get"%go) "$a0") in
     do:  ("totalBytes" <-[#uint64T] "$r0");;;
-    let: "buf" := (alloc (type.zero_val #sliceT)) in
+    let: "buf" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$s" := (![#sliceT] "startBuf") in
     slice.slice #byteT "$s" #(W64 8) (slice.len "$s")) in
     do:  ("buf" <-[#sliceT] "$r0");;;
-    let: "haveBytes" := (alloc (type.zero_val #uint64T)) in
+    let: "haveBytes" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (s_to_w64 (let: "$a0" := (![#sliceT] "buf") in
     slice.len "$a0")) in
     do:  ("haveBytes" <-[#uint64T] "$r0");;;
     (if: (![#uint64T] "haveBytes") < (![#uint64T] "totalBytes")
     then
-      let: "buf2" := (alloc (type.zero_val #sliceT)) in
+      let: "buf2" := (mem.alloc (type.zero_val #sliceT)) in
       let: "$r0" := (let: "$a0" := (![#fileT] "f") in
       let: "$a1" := ((![#uint64T] "off") + #(W64 512)) in
       let: "$a2" := ((![#uint64T] "totalBytes") - (![#uint64T] "haveBytes")) in
       (func_call #filesys #"ReadAt"%go) "$a0" "$a1" "$a2") in
       do:  ("buf2" <-[#sliceT] "$r0");;;
-      let: "newBuf" := (alloc (type.zero_val #sliceT)) in
+      let: "newBuf" := (mem.alloc (type.zero_val #sliceT)) in
       let: "$r0" := (let: "$a0" := (![#sliceT] "buf") in
       let: "$a1" := (![#sliceT] "buf2") in
       (slice.append #byteT) "$a0" "$a1") in
@@ -287,10 +287,10 @@ Definition readValue : val :=
 (* go: simpledb.go:137:6 *)
 Definition tableRead : val :=
   rec: "tableRead" "t" "k" :=
-    exception_do (let: "k" := (alloc "k") in
-    let: "t" := (alloc "t") in
-    let: "ok" := (alloc (type.zero_val #boolT)) in
-    let: "off" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "k" := (mem.alloc "k") in
+    let: "t" := (mem.alloc "t") in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
+    let: "off" := (mem.alloc (type.zero_val #uint64T)) in
     let: ("$ret0", "$ret1") := (map.get (![#(mapT uint64T uint64T)] (struct.field_ref #Table #"Index"%go "t")) (![#uint64T] "k")) in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
@@ -299,7 +299,7 @@ Definition tableRead : val :=
     (if: (~ (![#boolT] "ok"))
     then return: (#slice.nil, #false)
     else do:  #());;;
-    let: "p" := (alloc (type.zero_val #sliceT)) in
+    let: "p" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#fileT] (struct.field_ref #Table #"File"%go "t")) in
     let: "$a1" := (![#uint64T] "off") in
     (func_call #simpledb.simpledb #"readValue"%go) "$a0" "$a1") in
@@ -314,9 +314,9 @@ Definition bufFile : go_type := structT [
 (* go: simpledb.go:151:6 *)
 Definition newBuf : val :=
   rec: "newBuf" "f" :=
-    exception_do (let: "f" := (alloc "f") in
-    let: "buf" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "f" := (mem.alloc "f") in
+    let: "buf" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sliceT)) in
     do:  ("buf" <-[#ptrT] "$r0");;;
     return: (let: "$file" := (![#fileT] "f") in
      let: "$buf" := (![#ptrT] "buf") in
@@ -328,8 +328,8 @@ Definition newBuf : val :=
 (* go: simpledb.go:159:6 *)
 Definition bufFlush : val :=
   rec: "bufFlush" "f" :=
-    exception_do (let: "f" := (alloc "f") in
-    let: "buf" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "f" := (mem.alloc "f") in
+    let: "buf" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (![#sliceT] (![#ptrT] (struct.field_ref #bufFile #"buf"%go "f"))) in
     do:  ("buf" <-[#sliceT] "$r0");;;
     (if: (let: "$a0" := (![#sliceT] "buf") in
@@ -345,12 +345,12 @@ Definition bufFlush : val :=
 (* go: simpledb.go:168:6 *)
 Definition bufAppend : val :=
   rec: "bufAppend" "f" "p" :=
-    exception_do (let: "p" := (alloc "p") in
-    let: "f" := (alloc "f") in
-    let: "buf" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "p" := (mem.alloc "p") in
+    let: "f" := (mem.alloc "f") in
+    let: "buf" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (![#sliceT] (![#ptrT] (struct.field_ref #bufFile #"buf"%go "f"))) in
     do:  ("buf" <-[#sliceT] "$r0");;;
-    let: "buf2" := (alloc (type.zero_val #sliceT)) in
+    let: "buf2" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "buf") in
     let: "$a1" := (![#sliceT] "p") in
     (slice.append #byteT) "$a0" "$a1") in
@@ -361,7 +361,7 @@ Definition bufAppend : val :=
 (* go: simpledb.go:174:6 *)
 Definition bufClose : val :=
   rec: "bufClose" "f" :=
-    exception_do (let: "f" := (alloc "f") in
+    exception_do (let: "f" := (mem.alloc "f") in
     do:  (let: "$a0" := (![#bufFile] "f") in
     (func_call #simpledb.simpledb #"bufFlush"%go) "$a0");;;
     do:  (let: "$a0" := (![#fileT] (struct.field_ref #bufFile #"file"%go "f")) in
@@ -377,11 +377,11 @@ Definition tableWriter : go_type := structT [
 (* go: simpledb.go:186:6 *)
 Definition newTableWriter : val :=
   rec: "newTableWriter" "p" :=
-    exception_do (let: "p" := (alloc "p") in
-    let: "index" := (alloc (type.zero_val #(mapT uint64T uint64T))) in
+    exception_do (let: "p" := (mem.alloc "p") in
+    let: "index" := (mem.alloc (type.zero_val #(mapT uint64T uint64T))) in
     let: "$r0" := (map.make #uint64T #uint64T) in
     do:  ("index" <-[#(mapT uint64T uint64T)] "$r0");;;
-    let: "f" := (alloc (type.zero_val #fileT)) in
+    let: "f" := (mem.alloc (type.zero_val #fileT)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := #"db"%go in
     let: "$a1" := (![#stringT] "p") in
     (func_call #filesys #"Create"%go) "$a0" "$a1") in
@@ -389,12 +389,12 @@ Definition newTableWriter : val :=
     let: "$r1" := "$ret1" in
     do:  ("f" <-[#fileT] "$r0");;;
     do:  "$r1";;;
-    let: "buf" := (alloc (type.zero_val #bufFile)) in
+    let: "buf" := (mem.alloc (type.zero_val #bufFile)) in
     let: "$r0" := (let: "$a0" := (![#fileT] "f") in
     (func_call #simpledb.simpledb #"newBuf"%go) "$a0") in
     do:  ("buf" <-[#bufFile] "$r0");;;
-    let: "off" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #uint64T)) in
+    let: "off" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("off" <-[#ptrT] "$r0");;;
     return: (let: "$index" := (![#(mapT uint64T uint64T)] "index") in
      let: "$name" := (![#stringT] "p") in
@@ -410,12 +410,12 @@ Definition newTableWriter : val :=
 (* go: simpledb.go:199:6 *)
 Definition tableWriterAppend : val :=
   rec: "tableWriterAppend" "w" "p" :=
-    exception_do (let: "p" := (alloc "p") in
-    let: "w" := (alloc "w") in
+    exception_do (let: "p" := (mem.alloc "p") in
+    let: "w" := (mem.alloc "w") in
     do:  (let: "$a0" := (![#bufFile] (struct.field_ref #tableWriter #"file"%go "w")) in
     let: "$a1" := (![#sliceT] "p") in
     (func_call #simpledb.simpledb #"bufAppend"%go) "$a0" "$a1");;;
-    let: "off" := (alloc (type.zero_val #uint64T)) in
+    let: "off" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] (struct.field_ref #tableWriter #"offset"%go "w"))) in
     do:  ("off" <-[#uint64T] "$r0");;;
     let: "$r0" := ((![#uint64T] "off") + (s_to_w64 (let: "$a0" := (![#sliceT] "p") in
@@ -425,10 +425,10 @@ Definition tableWriterAppend : val :=
 (* go: simpledb.go:205:6 *)
 Definition tableWriterClose : val :=
   rec: "tableWriterClose" "w" :=
-    exception_do (let: "w" := (alloc "w") in
+    exception_do (let: "w" := (mem.alloc "w") in
     do:  (let: "$a0" := (![#bufFile] (struct.field_ref #tableWriter #"file"%go "w")) in
     (func_call #simpledb.simpledb #"bufClose"%go) "$a0");;;
-    let: "f" := (alloc (type.zero_val #fileT)) in
+    let: "f" := (mem.alloc (type.zero_val #fileT)) in
     let: "$r0" := (let: "$a0" := #"db"%go in
     let: "$a1" := (![#stringT] (struct.field_ref #tableWriter #"name"%go "w")) in
     (func_call #filesys #"Open"%go) "$a0" "$a1") in
@@ -445,15 +445,15 @@ Definition tableWriterClose : val :=
    go: simpledb.go:215:6 *)
 Definition EncodeUInt64 : val :=
   rec: "EncodeUInt64" "x" "p" :=
-    exception_do (let: "p" := (alloc "p") in
-    let: "x" := (alloc "x") in
-    let: "tmp" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "p" := (mem.alloc "p") in
+    let: "x" := (mem.alloc "x") in
+    let: "tmp" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 8)) in
     do:  ("tmp" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := (![#sliceT] "tmp") in
     let: "$a1" := (![#uint64T] "x") in
     (func_call #primitive #"UInt64Put"%go) "$a0" "$a1");;;
-    let: "p2" := (alloc (type.zero_val #sliceT)) in
+    let: "p2" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "p") in
     let: "$a1" := (![#sliceT] "tmp") in
     (slice.append #byteT) "$a0" "$a1") in
@@ -465,15 +465,15 @@ Definition EncodeUInt64 : val :=
    go: simpledb.go:223:6 *)
 Definition EncodeSlice : val :=
   rec: "EncodeSlice" "data" "p" :=
-    exception_do (let: "p" := (alloc "p") in
-    let: "data" := (alloc "data") in
-    let: "p2" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "p" := (mem.alloc "p") in
+    let: "data" := (mem.alloc "data") in
+    let: "p2" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (s_to_w64 (let: "$a0" := (![#sliceT] "data") in
     slice.len "$a0")) in
     let: "$a1" := (![#sliceT] "p") in
     (func_call #simpledb.simpledb #"EncodeUInt64"%go) "$a0" "$a1") in
     do:  ("p2" <-[#sliceT] "$r0");;;
-    let: "p3" := (alloc (type.zero_val #sliceT)) in
+    let: "p3" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "p2") in
     let: "$a1" := (![#sliceT] "data") in
     (slice.append #byteT) "$a0" "$a1") in
@@ -483,23 +483,23 @@ Definition EncodeSlice : val :=
 (* go: simpledb.go:229:6 *)
 Definition tablePut : val :=
   rec: "tablePut" "w" "k" "v" :=
-    exception_do (let: "v" := (alloc "v") in
-    let: "k" := (alloc "k") in
-    let: "w" := (alloc "w") in
-    let: "tmp" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "v" := (mem.alloc "v") in
+    let: "k" := (mem.alloc "k") in
+    let: "w" := (mem.alloc "w") in
+    let: "tmp" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 0)) in
     do:  ("tmp" <-[#sliceT] "$r0");;;
-    let: "tmp2" := (alloc (type.zero_val #sliceT)) in
+    let: "tmp2" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#uint64T] "k") in
     let: "$a1" := (![#sliceT] "tmp") in
     (func_call #simpledb.simpledb #"EncodeUInt64"%go) "$a0" "$a1") in
     do:  ("tmp2" <-[#sliceT] "$r0");;;
-    let: "tmp3" := (alloc (type.zero_val #sliceT)) in
+    let: "tmp3" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "v") in
     let: "$a1" := (![#sliceT] "tmp2") in
     (func_call #simpledb.simpledb #"EncodeSlice"%go) "$a0" "$a1") in
     do:  ("tmp3" <-[#sliceT] "$r0");;;
-    let: "off" := (alloc (type.zero_val #uint64T)) in
+    let: "off" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] (struct.field_ref #tableWriter #"offset"%go "w"))) in
     do:  ("off" <-[#uint64T] "$r0");;;
     let: "$r0" := ((![#uint64T] "off") + (s_to_w64 (let: "$a0" := (![#sliceT] "tmp2") in
@@ -522,11 +522,11 @@ Definition Database : go_type := structT [
 (* go: simpledb.go:256:6 *)
 Definition makeValueBuffer : val :=
   rec: "makeValueBuffer" <> :=
-    exception_do (let: "buf" := (alloc (type.zero_val #(mapT uint64T sliceT))) in
+    exception_do (let: "buf" := (mem.alloc (type.zero_val #(mapT uint64T sliceT))) in
     let: "$r0" := (map.make #uint64T #sliceT) in
     do:  ("buf" <-[#(mapT uint64T sliceT)] "$r0");;;
-    let: "bufPtr" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #(mapT uint64T sliceT))) in
+    let: "bufPtr" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #(mapT uint64T sliceT))) in
     do:  ("bufPtr" <-[#ptrT] "$r0");;;
     let: "$r0" := (![#(mapT uint64T sliceT)] "buf") in
     do:  ((![#ptrT] "bufPtr") <-[#(mapT uint64T sliceT)] "$r0");;;
@@ -537,37 +537,37 @@ Definition makeValueBuffer : val :=
    go: simpledb.go:264:6 *)
 Definition NewDb : val :=
   rec: "NewDb" <> :=
-    exception_do (let: "wbuf" := (alloc (type.zero_val #ptrT)) in
+    exception_do (let: "wbuf" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := ((func_call #simpledb.simpledb #"makeValueBuffer"%go) #()) in
     do:  ("wbuf" <-[#ptrT] "$r0");;;
-    let: "rbuf" := (alloc (type.zero_val #ptrT)) in
+    let: "rbuf" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := ((func_call #simpledb.simpledb #"makeValueBuffer"%go) #()) in
     do:  ("rbuf" <-[#ptrT] "$r0");;;
-    let: "bufferL" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    let: "bufferL" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("bufferL" <-[#ptrT] "$r0");;;
-    let: "tableName" := (alloc (type.zero_val #stringT)) in
+    let: "tableName" := (mem.alloc (type.zero_val #stringT)) in
     let: "$r0" := #"table.0"%go in
     do:  ("tableName" <-[#stringT] "$r0");;;
-    let: "tableNameRef" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #stringT)) in
+    let: "tableNameRef" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #stringT)) in
     do:  ("tableNameRef" <-[#ptrT] "$r0");;;
     let: "$r0" := (![#stringT] "tableName") in
     do:  ((![#ptrT] "tableNameRef") <-[#stringT] "$r0");;;
-    let: "table" := (alloc (type.zero_val #Table)) in
+    let: "table" := (mem.alloc (type.zero_val #Table)) in
     let: "$r0" := (let: "$a0" := (![#stringT] "tableName") in
     (func_call #simpledb.simpledb #"CreateTable"%go) "$a0") in
     do:  ("table" <-[#Table] "$r0");;;
-    let: "tableRef" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #Table)) in
+    let: "tableRef" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #Table)) in
     do:  ("tableRef" <-[#ptrT] "$r0");;;
     let: "$r0" := (![#Table] "table") in
     do:  ((![#ptrT] "tableRef") <-[#Table] "$r0");;;
-    let: "tableL" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    let: "tableL" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("tableL" <-[#ptrT] "$r0");;;
-    let: "compactionL" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    let: "compactionL" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("compactionL" <-[#ptrT] "$r0");;;
     return: (let: "$wbuffer" := (![#ptrT] "wbuf") in
      let: "$rbuffer" := (![#ptrT] "rbuf") in
@@ -596,14 +596,14 @@ Definition NewDb : val :=
    go: simpledb.go:293:6 *)
 Definition Read : val :=
   rec: "Read" "db" "k" :=
-    exception_do (let: "k" := (alloc "k") in
-    let: "db" := (alloc "db") in
+    exception_do (let: "k" := (mem.alloc "k") in
+    let: "db" := (mem.alloc "db") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Database #"bufferL"%go "db"))) #());;;
-    let: "buf" := (alloc (type.zero_val #(mapT uint64T sliceT))) in
+    let: "buf" := (mem.alloc (type.zero_val #(mapT uint64T sliceT))) in
     let: "$r0" := (![#(mapT uint64T sliceT)] (![#ptrT] (struct.field_ref #Database #"wbuffer"%go "db"))) in
     do:  ("buf" <-[#(mapT uint64T sliceT)] "$r0");;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
-    let: "v" := (alloc (type.zero_val #sliceT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
+    let: "v" := (mem.alloc (type.zero_val #sliceT)) in
     let: ("$ret0", "$ret1") := (map.get (![#(mapT uint64T sliceT)] "buf") (![#uint64T] "k")) in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
@@ -614,10 +614,10 @@ Definition Read : val :=
       do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Database #"bufferL"%go "db"))) #());;;
       return: (![#sliceT] "v", #true)
     else do:  #());;;
-    let: "rbuf" := (alloc (type.zero_val #(mapT uint64T sliceT))) in
+    let: "rbuf" := (mem.alloc (type.zero_val #(mapT uint64T sliceT))) in
     let: "$r0" := (![#(mapT uint64T sliceT)] (![#ptrT] (struct.field_ref #Database #"rbuffer"%go "db"))) in
     do:  ("rbuf" <-[#(mapT uint64T sliceT)] "$r0");;;
-    let: "v2" := (alloc (type.zero_val #sliceT)) in
+    let: "v2" := (mem.alloc (type.zero_val #sliceT)) in
     let: ("$ret0", "$ret1") := (map.get (![#(mapT uint64T sliceT)] "rbuf") (![#uint64T] "k")) in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
@@ -629,10 +629,10 @@ Definition Read : val :=
       return: (![#sliceT] "v2", #true)
     else do:  #());;;
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Database #"tableL"%go "db"))) #());;;
-    let: "tbl" := (alloc (type.zero_val #Table)) in
+    let: "tbl" := (mem.alloc (type.zero_val #Table)) in
     let: "$r0" := (![#Table] (![#ptrT] (struct.field_ref #Database #"table"%go "db"))) in
     do:  ("tbl" <-[#Table] "$r0");;;
-    let: "v3" := (alloc (type.zero_val #sliceT)) in
+    let: "v3" := (mem.alloc (type.zero_val #sliceT)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := (![#Table] "tbl") in
     let: "$a1" := (![#uint64T] "k") in
     (func_call #simpledb.simpledb #"tableRead"%go) "$a0" "$a1") in
@@ -654,11 +654,11 @@ Definition Read : val :=
    go: simpledb.go:326:6 *)
 Definition Write : val :=
   rec: "Write" "db" "k" "v" :=
-    exception_do (let: "v" := (alloc "v") in
-    let: "k" := (alloc "k") in
-    let: "db" := (alloc "db") in
+    exception_do (let: "v" := (mem.alloc "v") in
+    let: "k" := (mem.alloc "k") in
+    let: "db" := (mem.alloc "db") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Database #"bufferL"%go "db"))) #());;;
-    let: "buf" := (alloc (type.zero_val #(mapT uint64T sliceT))) in
+    let: "buf" := (mem.alloc (type.zero_val #(mapT uint64T sliceT))) in
     let: "$r0" := (![#(mapT uint64T sliceT)] (![#ptrT] (struct.field_ref #Database #"wbuffer"%go "db"))) in
     do:  ("buf" <-[#(mapT uint64T sliceT)] "$r0");;;
     let: "$r0" := (![#sliceT] "v") in
@@ -668,7 +668,7 @@ Definition Write : val :=
 (* go: simpledb.go:333:6 *)
 Definition freshTable : val :=
   rec: "freshTable" "p" :=
-    exception_do (let: "p" := (alloc "p") in
+    exception_do (let: "p" := (mem.alloc "p") in
     (if: (![#stringT] "p") = #"table.0"%go
     then return: (#"table.1"%go)
     else do:  #());;;
@@ -680,11 +680,11 @@ Definition freshTable : val :=
 (* go: simpledb.go:345:6 *)
 Definition tablePutBuffer : val :=
   rec: "tablePutBuffer" "w" "buf" :=
-    exception_do (let: "buf" := (alloc "buf") in
-    let: "w" := (alloc "w") in
+    exception_do (let: "buf" := (mem.alloc "buf") in
+    let: "w" := (mem.alloc "w") in
     let: "$range" := (![#(mapT uint64T sliceT)] "buf") in
-    (let: "v" := (alloc (type.zero_val #uint64T)) in
-    let: "k" := (alloc (type.zero_val #uint64T)) in
+    (let: "v" := (mem.alloc (type.zero_val #uint64T)) in
+    let: "k" := (mem.alloc (type.zero_val #uint64T)) in
     map.for_range "$range" (λ: "$key" "value",
       do:  ("v" <-[#sliceT] "$value");;;
       do:  ("k" <-[#uint64T] "$key");;;
@@ -699,10 +699,10 @@ Definition tablePutBuffer : val :=
    go: simpledb.go:353:6 *)
 Definition tablePutOldTable : val :=
   rec: "tablePutOldTable" "w" "t" "b" :=
-    exception_do (let: "b" := (alloc "b") in
-    let: "t" := (alloc "t") in
-    let: "w" := (alloc "w") in
-    (let: "buf" := (alloc (type.zero_val #lazyFileBuf)) in
+    exception_do (let: "b" := (mem.alloc "b") in
+    let: "t" := (mem.alloc "t") in
+    let: "w" := (mem.alloc "w") in
+    (let: "buf" := (mem.alloc (type.zero_val #lazyFileBuf)) in
     let: "$r0" := (let: "$offset" := #(W64 0) in
     let: "$next" := #slice.nil in
     struct.make #lazyFileBuf [{
@@ -711,8 +711,8 @@ Definition tablePutOldTable : val :=
     }]) in
     do:  ("buf" <-[#lazyFileBuf] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
-      let: "l" := (alloc (type.zero_val #uint64T)) in
-      let: "e" := (alloc (type.zero_val #Entry)) in
+      let: "l" := (mem.alloc (type.zero_val #uint64T)) in
+      let: "e" := (mem.alloc (type.zero_val #Entry)) in
       let: ("$ret0", "$ret1") := (let: "$a0" := (![#sliceT] (struct.field_ref #lazyFileBuf #"next"%go "buf")) in
       (func_call #simpledb.simpledb #"DecodeEntry"%go) "$a0") in
       let: "$r0" := "$ret0" in
@@ -721,7 +721,7 @@ Definition tablePutOldTable : val :=
       do:  ("l" <-[#uint64T] "$r1");;;
       (if: (![#uint64T] "l") > #(W64 0)
       then
-        let: "ok" := (alloc (type.zero_val #boolT)) in
+        let: "ok" := (mem.alloc (type.zero_val #boolT)) in
         let: ("$ret0", "$ret1") := (map.get (![#(mapT uint64T sliceT)] "b") (![#uint64T] (struct.field_ref #Entry #"Key"%go "e"))) in
         let: "$r0" := "$ret0" in
         let: "$r1" := "$ret1" in
@@ -744,7 +744,7 @@ Definition tablePutOldTable : val :=
         do:  ("buf" <-[#lazyFileBuf] "$r0");;;
         continue: #()
       else
-        let: "p" := (alloc (type.zero_val #sliceT)) in
+        let: "p" := (mem.alloc (type.zero_val #sliceT)) in
         let: "$r0" := (let: "$a0" := (![#fileT] (struct.field_ref #Table #"File"%go "t")) in
         let: "$a1" := ((![#uint64T] (struct.field_ref #lazyFileBuf #"offset"%go "buf")) + (s_to_w64 (let: "$a0" := (![#sliceT] (struct.field_ref #lazyFileBuf #"next"%go "buf")) in
         slice.len "$a0"))) in
@@ -755,7 +755,7 @@ Definition tablePutOldTable : val :=
         slice.len "$a0") = #(W64 0)
         then break: #()
         else
-          let: "newBuf" := (alloc (type.zero_val #sliceT)) in
+          let: "newBuf" := (mem.alloc (type.zero_val #sliceT)) in
           let: "$r0" := (let: "$a0" := (![#sliceT] (struct.field_ref #lazyFileBuf #"next"%go "buf")) in
           let: "$a1" := (![#sliceT] "p") in
           (slice.append #byteT) "$a0" "$a1") in
@@ -779,20 +779,20 @@ Definition tablePutOldTable : val :=
    go: simpledb.go:388:6 *)
 Definition constructNewTable : val :=
   rec: "constructNewTable" "db" "wbuf" :=
-    exception_do (let: "wbuf" := (alloc "wbuf") in
-    let: "db" := (alloc "db") in
-    let: "oldName" := (alloc (type.zero_val #stringT)) in
+    exception_do (let: "wbuf" := (mem.alloc "wbuf") in
+    let: "db" := (mem.alloc "db") in
+    let: "oldName" := (mem.alloc (type.zero_val #stringT)) in
     let: "$r0" := (![#stringT] (![#ptrT] (struct.field_ref #Database #"tableName"%go "db"))) in
     do:  ("oldName" <-[#stringT] "$r0");;;
-    let: "name" := (alloc (type.zero_val #stringT)) in
+    let: "name" := (mem.alloc (type.zero_val #stringT)) in
     let: "$r0" := (let: "$a0" := (![#stringT] "oldName") in
     (func_call #simpledb.simpledb #"freshTable"%go) "$a0") in
     do:  ("name" <-[#stringT] "$r0");;;
-    let: "w" := (alloc (type.zero_val #tableWriter)) in
+    let: "w" := (mem.alloc (type.zero_val #tableWriter)) in
     let: "$r0" := (let: "$a0" := (![#stringT] "name") in
     (func_call #simpledb.simpledb #"newTableWriter"%go) "$a0") in
     do:  ("w" <-[#tableWriter] "$r0");;;
-    let: "oldTable" := (alloc (type.zero_val #Table)) in
+    let: "oldTable" := (mem.alloc (type.zero_val #Table)) in
     let: "$r0" := (![#Table] (![#ptrT] (struct.field_ref #Database #"table"%go "db"))) in
     do:  ("oldTable" <-[#Table] "$r0");;;
     do:  (let: "$a0" := (![#tableWriter] "w") in
@@ -802,7 +802,7 @@ Definition constructNewTable : val :=
     do:  (let: "$a0" := (![#tableWriter] "w") in
     let: "$a1" := (![#(mapT uint64T sliceT)] "wbuf") in
     (func_call #simpledb.simpledb #"tablePutBuffer"%go) "$a0" "$a1");;;
-    let: "newTable" := (alloc (type.zero_val #Table)) in
+    let: "newTable" := (mem.alloc (type.zero_val #Table)) in
     let: "$r0" := (let: "$a0" := (![#tableWriter] "w") in
     (func_call #simpledb.simpledb #"tableWriterClose"%go) "$a0") in
     do:  ("newTable" <-[#Table] "$r0");;;
@@ -816,13 +816,13 @@ Definition constructNewTable : val :=
    go: simpledb.go:405:6 *)
 Definition Compact : val :=
   rec: "Compact" "db" :=
-    exception_do (let: "db" := (alloc "db") in
+    exception_do (let: "db" := (mem.alloc "db") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Database #"compactionL"%go "db"))) #());;;
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Database #"bufferL"%go "db"))) #());;;
-    let: "buf" := (alloc (type.zero_val #(mapT uint64T sliceT))) in
+    let: "buf" := (mem.alloc (type.zero_val #(mapT uint64T sliceT))) in
     let: "$r0" := (![#(mapT uint64T sliceT)] (![#ptrT] (struct.field_ref #Database #"wbuffer"%go "db"))) in
     do:  ("buf" <-[#(mapT uint64T sliceT)] "$r0");;;
-    let: "emptyWbuffer" := (alloc (type.zero_val #(mapT uint64T sliceT))) in
+    let: "emptyWbuffer" := (mem.alloc (type.zero_val #(mapT uint64T sliceT))) in
     let: "$r0" := (map.make #uint64T #sliceT) in
     do:  ("emptyWbuffer" <-[#(mapT uint64T sliceT)] "$r0");;;
     let: "$r0" := (![#(mapT uint64T sliceT)] "emptyWbuffer") in
@@ -831,11 +831,11 @@ Definition Compact : val :=
     do:  ((![#ptrT] (struct.field_ref #Database #"rbuffer"%go "db")) <-[#(mapT uint64T sliceT)] "$r0");;;
     do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Database #"bufferL"%go "db"))) #());;;
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Database #"tableL"%go "db"))) #());;;
-    let: "oldTableName" := (alloc (type.zero_val #stringT)) in
+    let: "oldTableName" := (mem.alloc (type.zero_val #stringT)) in
     let: "$r0" := (![#stringT] (![#ptrT] (struct.field_ref #Database #"tableName"%go "db"))) in
     do:  ("oldTableName" <-[#stringT] "$r0");;;
-    let: "t" := (alloc (type.zero_val #Table)) in
-    let: "oldTable" := (alloc (type.zero_val #Table)) in
+    let: "t" := (mem.alloc (type.zero_val #Table)) in
+    let: "oldTable" := (mem.alloc (type.zero_val #Table)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := (![#Database] "db") in
     let: "$a1" := (![#(mapT uint64T sliceT)] "buf") in
     (func_call #simpledb.simpledb #"constructNewTable"%go) "$a0" "$a1") in
@@ -843,7 +843,7 @@ Definition Compact : val :=
     let: "$r1" := "$ret1" in
     do:  ("oldTable" <-[#Table] "$r0");;;
     do:  ("t" <-[#Table] "$r1");;;
-    let: "newTable" := (alloc (type.zero_val #stringT)) in
+    let: "newTable" := (mem.alloc (type.zero_val #stringT)) in
     let: "$r0" := (let: "$a0" := (![#stringT] "oldTableName") in
     (func_call #simpledb.simpledb #"freshTable"%go) "$a0") in
     do:  ("newTable" <-[#stringT] "$r0");;;
@@ -851,7 +851,7 @@ Definition Compact : val :=
     do:  ((![#ptrT] (struct.field_ref #Database #"table"%go "db")) <-[#Table] "$r0");;;
     let: "$r0" := (![#stringT] "newTable") in
     do:  ((![#ptrT] (struct.field_ref #Database #"tableName"%go "db")) <-[#stringT] "$r0");;;
-    let: "manifestData" := (alloc (type.zero_val #sliceT)) in
+    let: "manifestData" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (string.to_bytes (![#stringT] "newTable")) in
     do:  ("manifestData" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := #"db"%go in
@@ -869,18 +869,18 @@ Definition Compact : val :=
 (* go: simpledb.go:450:6 *)
 Definition recoverManifest : val :=
   rec: "recoverManifest" <> :=
-    exception_do (let: "f" := (alloc (type.zero_val #fileT)) in
+    exception_do (let: "f" := (mem.alloc (type.zero_val #fileT)) in
     let: "$r0" := (let: "$a0" := #"db"%go in
     let: "$a1" := #"manifest"%go in
     (func_call #filesys #"Open"%go) "$a0" "$a1") in
     do:  ("f" <-[#fileT] "$r0");;;
-    let: "manifestData" := (alloc (type.zero_val #sliceT)) in
+    let: "manifestData" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#fileT] "f") in
     let: "$a1" := #(W64 0) in
     let: "$a2" := #(W64 4096) in
     (func_call #filesys #"ReadAt"%go) "$a0" "$a1" "$a2") in
     do:  ("manifestData" <-[#sliceT] "$r0");;;
-    let: "tableName" := (alloc (type.zero_val #stringT)) in
+    let: "tableName" := (mem.alloc (type.zero_val #stringT)) in
     let: "$r0" := (string.from_bytes (![#sliceT] "manifestData")) in
     do:  ("tableName" <-[#stringT] "$r0");;;
     do:  (let: "$a0" := (![#fileT] "f") in
@@ -892,8 +892,8 @@ Definition recoverManifest : val :=
    go: simpledb.go:464:6 *)
 Definition deleteOtherFile : val :=
   rec: "deleteOtherFile" "name" "tableName" :=
-    exception_do (let: "tableName" := (alloc "tableName") in
-    let: "name" := (alloc "name") in
+    exception_do (let: "tableName" := (mem.alloc "tableName") in
+    let: "name" := (mem.alloc "name") in
     (if: (![#stringT] "name") = (![#stringT] "tableName")
     then return: (#())
     else do:  #());;;
@@ -907,23 +907,23 @@ Definition deleteOtherFile : val :=
 (* go: simpledb.go:474:6 *)
 Definition deleteOtherFiles : val :=
   rec: "deleteOtherFiles" "tableName" :=
-    exception_do (let: "tableName" := (alloc "tableName") in
-    let: "files" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "tableName" := (mem.alloc "tableName") in
+    let: "files" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := #"db"%go in
     (func_call #filesys #"List"%go) "$a0") in
     do:  ("files" <-[#sliceT] "$r0");;;
-    let: "nfiles" := (alloc (type.zero_val #uint64T)) in
+    let: "nfiles" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (s_to_w64 (let: "$a0" := (![#sliceT] "files") in
     slice.len "$a0")) in
     do:  ("nfiles" <-[#uint64T] "$r0");;;
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
       (if: (![#uint64T] "i") = (![#uint64T] "nfiles")
       then break: #()
       else do:  #());;;
-      let: "name" := (alloc (type.zero_val #stringT)) in
+      let: "name" := (mem.alloc (type.zero_val #stringT)) in
       let: "$r0" := (![#stringT] (slice.elem_ref #stringT (![#sliceT] "files") (![#uint64T] "i"))) in
       do:  ("name" <-[#stringT] "$r0");;;
       do:  (let: "$a0" := (![#stringT] "name") in
@@ -938,39 +938,39 @@ Definition deleteOtherFiles : val :=
    go: simpledb.go:489:6 *)
 Definition Recover : val :=
   rec: "Recover" <> :=
-    exception_do (let: "tableName" := (alloc (type.zero_val #stringT)) in
+    exception_do (let: "tableName" := (mem.alloc (type.zero_val #stringT)) in
     let: "$r0" := ((func_call #simpledb.simpledb #"recoverManifest"%go) #()) in
     do:  ("tableName" <-[#stringT] "$r0");;;
-    let: "table" := (alloc (type.zero_val #Table)) in
+    let: "table" := (mem.alloc (type.zero_val #Table)) in
     let: "$r0" := (let: "$a0" := (![#stringT] "tableName") in
     (func_call #simpledb.simpledb #"RecoverTable"%go) "$a0") in
     do:  ("table" <-[#Table] "$r0");;;
-    let: "tableRef" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #Table)) in
+    let: "tableRef" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #Table)) in
     do:  ("tableRef" <-[#ptrT] "$r0");;;
     let: "$r0" := (![#Table] "table") in
     do:  ((![#ptrT] "tableRef") <-[#Table] "$r0");;;
-    let: "tableNameRef" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #stringT)) in
+    let: "tableNameRef" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #stringT)) in
     do:  ("tableNameRef" <-[#ptrT] "$r0");;;
     let: "$r0" := (![#stringT] "tableName") in
     do:  ((![#ptrT] "tableNameRef") <-[#stringT] "$r0");;;
     do:  (let: "$a0" := (![#stringT] "tableName") in
     (func_call #simpledb.simpledb #"deleteOtherFiles"%go) "$a0");;;
-    let: "wbuffer" := (alloc (type.zero_val #ptrT)) in
+    let: "wbuffer" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := ((func_call #simpledb.simpledb #"makeValueBuffer"%go) #()) in
     do:  ("wbuffer" <-[#ptrT] "$r0");;;
-    let: "rbuffer" := (alloc (type.zero_val #ptrT)) in
+    let: "rbuffer" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := ((func_call #simpledb.simpledb #"makeValueBuffer"%go) #()) in
     do:  ("rbuffer" <-[#ptrT] "$r0");;;
-    let: "bufferL" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    let: "bufferL" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("bufferL" <-[#ptrT] "$r0");;;
-    let: "tableL" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    let: "tableL" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("tableL" <-[#ptrT] "$r0");;;
-    let: "compactionL" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    let: "compactionL" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("compactionL" <-[#ptrT] "$r0");;;
     return: (let: "$wbuffer" := (![#ptrT] "wbuffer") in
      let: "$rbuffer" := (![#ptrT] "rbuffer") in
@@ -997,10 +997,10 @@ Definition Recover : val :=
    go: simpledb.go:520:6 *)
 Definition Shutdown : val :=
   rec: "Shutdown" "db" :=
-    exception_do (let: "db" := (alloc "db") in
+    exception_do (let: "db" := (mem.alloc "db") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Database #"bufferL"%go "db"))) #());;;
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Database #"compactionL"%go "db"))) #());;;
-    let: "t" := (alloc (type.zero_val #Table)) in
+    let: "t" := (mem.alloc (type.zero_val #Table)) in
     let: "$r0" := (![#Table] (![#ptrT] (struct.field_ref #Database #"table"%go "db"))) in
     do:  ("t" <-[#Table] "$r0");;;
     do:  (let: "$a0" := (![#Table] "t") in
@@ -1015,7 +1015,7 @@ Definition Shutdown : val :=
    go: simpledb.go:534:6 *)
 Definition Close : val :=
   rec: "Close" "db" :=
-    exception_do (let: "db" := (alloc "db") in
+    exception_do (let: "db" := (mem.alloc "db") in
     do:  (let: "$a0" := (![#Database] "db") in
     (func_call #simpledb.simpledb #"Compact"%go) "$a0");;;
     do:  (let: "$a0" := (![#Database] "db") in

--- a/testdata/examples/unittest/unittest.gold.v
+++ b/testdata/examples/unittest/unittest.gold.v
@@ -19,19 +19,19 @@ Definition Foo : go_type := arrayT 10 uint64T.
 (* go: array.go:5:6 *)
 Definition takesArray : val :=
   rec: "takesArray" "x" :=
-    exception_do (let: "x" := (alloc "x") in
+    exception_do (let: "x" := (mem.alloc "x") in
     return: (![#stringT] (array.elem_ref #stringT (![#(arrayT 13 stringT)] "x") #(W64 3)))).
 
 (* go: array.go:9:6 *)
 Definition takesPtr : val :=
   rec: "takesPtr" "x" :=
-    exception_do (let: "x" := (alloc "x") in
+    exception_do (let: "x" := (mem.alloc "x") in
     do:  ((![#ptrT] "x") <-[#stringT] ((![#stringT] (![#ptrT] "x")) + #"bar"%go))).
 
 (* go: array.go:13:6 *)
 Definition usesArrayElemRef : val :=
   rec: "usesArrayElemRef" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #(arrayT 2 stringT))) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #(arrayT 2 stringT))) in
     let: "$r0" := ((let: "$ar0" := #"a"%go in
     let: "$ar1" := #"b"%go in
     array.literal ["$ar0"; "$ar1"])) in
@@ -44,11 +44,11 @@ Definition usesArrayElemRef : val :=
 (* go: array.go:22:6 *)
 Definition sum : val :=
   rec: "sum" "x" :=
-    exception_do (let: "x" := (alloc "x") in
-    let: "sum" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc "x") in
+    let: "sum" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("sum" <-[#uint64T] "$r0");;;
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < (s_to_w64 (array.len #(arrayT 100 uint64T)))); (λ: <>, do:  ("i" <-[#uint64T] ((![#uint64T] "i") + #(W64 1)))) := λ: <>,
@@ -59,7 +59,7 @@ Definition sum : val :=
 (* go: array.go:31:6 *)
 Definition arrayToSlice : val :=
   rec: "arrayToSlice" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #(arrayT 2 stringT))) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #(arrayT 2 stringT))) in
     let: "$r0" := ((let: "$ar0" := #"a"%go in
     let: "$ar1" := #"b"%go in
     array.literal ["$ar0"; "$ar1"])) in
@@ -74,7 +74,7 @@ Definition arrayB : Z := 10.
 (* go: array.go:44:6 *)
 Definition arrayLiteralKeyed : val :=
   rec: "arrayLiteralKeyed" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #(arrayT 13 stringT))) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #(arrayT 13 stringT))) in
     let: "$r0" := ((let: "$ar0" := #"A"%go in
     let: "$ar1" := #"3"%go in
     let: "$ar2" := (type.zero_val #stringT) in
@@ -95,7 +95,7 @@ Definition arrayLiteralKeyed : val :=
 (* go: chan.go:5:6 *)
 Definition chanBasic : val :=
   rec: "chanBasic" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #(chanT stringT))) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #(chanT stringT))) in
     let: "$r0" := (chan.make stringT #(W64 10)) in
     do:  ("x" <-[#(chanT stringT)] "$r0");;;
     let: "$r0" := (chan.make stringT #(W64 0)) in
@@ -109,8 +109,8 @@ Definition chanBasic : val :=
       chan.send "$chan" "$v"))
       ) in
     do:  (Fork ("$go" #()));;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
-    let: "y" := (alloc (type.zero_val #stringT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
+    let: "y" := (mem.alloc (type.zero_val #stringT)) in
     let: ("$ret0", "$ret1") := (chan.receive (![#(chanT stringT)] "x")) in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
@@ -134,14 +134,14 @@ Definition f : val :=
    go: chan.go:25:6 *)
 Definition chanSelect : val :=
   rec: "chanSelect" <> :=
-    exception_do (let: "a" := (alloc (type.zero_val #sliceT)) in
-    let: "c4" := (alloc (type.zero_val #(chanT intT))) in
-    let: "c3" := (alloc (type.zero_val #(chanT intT))) in
-    let: "c2" := (alloc (type.zero_val #(chanT intT))) in
-    let: "c1" := (alloc (type.zero_val #(chanT intT))) in
-    let: "c" := (alloc (type.zero_val #(chanT intT))) in
-    let: "i2" := (alloc (type.zero_val #intT)) in
-    let: "i1" := (alloc (type.zero_val #intT)) in
+    exception_do (let: "a" := (mem.alloc (type.zero_val #sliceT)) in
+    let: "c4" := (mem.alloc (type.zero_val #(chanT intT))) in
+    let: "c3" := (mem.alloc (type.zero_val #(chanT intT))) in
+    let: "c2" := (mem.alloc (type.zero_val #(chanT intT))) in
+    let: "c1" := (mem.alloc (type.zero_val #(chanT intT))) in
+    let: "c" := (mem.alloc (type.zero_val #(chanT intT))) in
+    let: "i2" := (mem.alloc (type.zero_val #intT)) in
+    let: "i1" := (mem.alloc (type.zero_val #intT)) in
     do:  (chan.select [("$sendVal0", "$sendChan0", (λ: <>,
         do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"sent "%go) in
         let: "$sl1" := (interface.make #""%go #"int"%go (![#intT] "i2")) in
@@ -161,8 +161,8 @@ Definition chanSelect : val :=
         slice.literal #interfaceT ["$sl0"; "$sl1"; "$sl2"])) in
         (func_call #fmt #"Print"%go) "$a0")
         )); ("$recvChan2", (λ: "$recvVal",
-        let: "ok" := (alloc (type.zero_val #boolT)) in
-        let: "i3" := (alloc (type.zero_val #intT)) in
+        let: "ok" := (mem.alloc (type.zero_val #boolT)) in
+        let: "i3" := (mem.alloc (type.zero_val #intT)) in
         let: ("$ret0", "$ret1") := "$recvVal" in
         let: "$r0" := "$ret0" in
         let: "$r1" := "$ret1" in
@@ -202,8 +202,8 @@ Definition chanSelect : val :=
 (* go: chan.go:59:6 *)
 Definition chanDirectional : val :=
   rec: "chanDirectional" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #(chanT uint64T))) in
-    let: "y" := (alloc (type.zero_val #(chanT stringT))) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #(chanT uint64T))) in
+    let: "y" := (mem.alloc (type.zero_val #(chanT stringT))) in
     do:  (Fst (chan.receive (![#(chanT uint64T)] "x")));;;
     do:  (let: "$chan" := (![#(chanT stringT)] "y") in
     let: "$v" := #""%go in
@@ -212,16 +212,16 @@ Definition chanDirectional : val :=
 (* go: chan.go:66:6 *)
 Definition chanRange : val :=
   rec: "chanRange" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #(chanT uint64T))) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #(chanT uint64T))) in
     let: "$range" := (![#(chanT uint64T)] "x") in
-    (let: "y" := (alloc (type.zero_val #uint64T)) in
+    (let: "y" := (mem.alloc (type.zero_val #uint64T)) in
     chan.for_range "$range" (λ: "$key",
       do:  ("y" <-[#uint64T] "$key");;;
       do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"uint64"%go (![#uint64T] "y")) in
       slice.literal #interfaceT ["$sl0"])) in
       (func_call #fmt #"Print"%go) "$a0")));;;
     let: "$range" := (![#(chanT uint64T)] "x") in
-    (let: "x" := (alloc (type.zero_val #uint64T)) in
+    (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     chan.for_range "$range" (λ: "$key",
       do:  ("x" <-[#uint64T] "$key");;;
       do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"uint64"%go (![#uint64T] "x")) in
@@ -260,14 +260,14 @@ Definition hasEndComment : val :=
 (* go: condvar.go:5:6 *)
 Definition condvarWrapping : val :=
   rec: "condvarWrapping" <> :=
-    exception_do (let: "mu" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    exception_do (let: "mu" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("mu" <-[#ptrT] "$r0");;;
-    let: "cond1" := (alloc (type.zero_val #ptrT)) in
+    let: "cond1" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (let: "$a0" := (interface.make #sync #"Mutex'ptr" (![#ptrT] "mu")) in
     (func_call #sync #"NewCond"%go) "$a0") in
     do:  ("cond1" <-[#ptrT] "$r0");;;
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("mu" <-[#ptrT] "$r0");;;
     do:  ((method_call #sync #"Cond'ptr" #"Wait" (![#ptrT] "cond1")) #())).
 
@@ -319,7 +319,7 @@ Definition useUntypedString : val :=
 (* go: control_flow.go:3:6 *)
 Definition conditionalReturn : val :=
   rec: "conditionalReturn" "x" :=
-    exception_do (let: "x" := (alloc "x") in
+    exception_do (let: "x" := (mem.alloc "x") in
     (if: ![#boolT] "x"
     then return: (#(W64 0))
     else do:  #());;;
@@ -328,7 +328,7 @@ Definition conditionalReturn : val :=
 (* go: control_flow.go:10:6 *)
 Definition alwaysReturn : val :=
   rec: "alwaysReturn" "x" :=
-    exception_do (let: "x" := (alloc "x") in
+    exception_do (let: "x" := (mem.alloc "x") in
     (if: ![#boolT] "x"
     then return: (#(W64 0))
     else return: (#(W64 1)))).
@@ -336,14 +336,14 @@ Definition alwaysReturn : val :=
 (* go: control_flow.go:18:6 *)
 Definition alwaysReturnInNestedBranches : val :=
   rec: "alwaysReturnInNestedBranches" "x" :=
-    exception_do (let: "x" := (alloc "x") in
+    exception_do (let: "x" := (mem.alloc "x") in
     (if: (~ (![#boolT] "x"))
     then
       (if: ![#boolT] "x"
       then return: (#(W64 0))
       else return: (#(W64 1)))
     else do:  #());;;
-    let: "y" := (alloc (type.zero_val #uint64T)) in
+    let: "y" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 14) in
     do:  ("y" <-[#uint64T] "$r0");;;
     return: (![#uint64T] "y")).
@@ -351,7 +351,7 @@ Definition alwaysReturnInNestedBranches : val :=
 (* go: control_flow.go:32:6 *)
 Definition earlyReturn : val :=
   rec: "earlyReturn" "x" :=
-    exception_do (let: "x" := (alloc "x") in
+    exception_do (let: "x" := (mem.alloc "x") in
     (if: ![#boolT] "x"
     then return: (#())
     else do:  #())).
@@ -359,8 +359,8 @@ Definition earlyReturn : val :=
 (* go: control_flow.go:38:6 *)
 Definition conditionalAssign : val :=
   rec: "conditionalAssign" "x" :=
-    exception_do (let: "x" := (alloc "x") in
-    let: "y" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc "x") in
+    let: "y" := (mem.alloc (type.zero_val #uint64T)) in
     (if: ![#boolT] "x"
     then
       let: "$r0" := #(W64 1) in
@@ -374,8 +374,8 @@ Definition conditionalAssign : val :=
 (* go: control_flow.go:49:6 *)
 Definition elseIf : val :=
   rec: "elseIf" "x" "y" :=
-    exception_do (let: "y" := (alloc "y") in
-    let: "x" := (alloc "x") in
+    exception_do (let: "y" := (mem.alloc "y") in
+    let: "x" := (mem.alloc "x") in
     (if: ![#boolT] "x"
     then return: (#(W64 0))
     else
@@ -386,8 +386,8 @@ Definition elseIf : val :=
 (* go: control_flow.go:59:6 *)
 Definition ifStmtInitialization : val :=
   rec: "ifStmtInitialization" "x" :=
-    exception_do (let: "x" := (alloc "x") in
-    let: "f" := (alloc (type.zero_val #funcT)) in
+    exception_do (let: "x" := (mem.alloc "x") in
+    let: "f" := (mem.alloc (type.zero_val #funcT)) in
     let: "$r0" := (λ: <>,
       exception_do (return: (![#uint64T] "x"))
       ) in
@@ -396,13 +396,13 @@ Definition ifStmtInitialization : val :=
     (if: (![#uint64T] "x") = #(W64 2)
     then do:  #()
     else
-      (let: "z" := (alloc (type.zero_val #uint64T)) in
+      (let: "z" := (mem.alloc (type.zero_val #uint64T)) in
       let: "$r0" := (![#uint64T] "x") in
       do:  ("z" <-[#uint64T] "$r0");;;
       (if: (![#uint64T] "z") = #(W64 1)
       then do:  #()
       else
-        (let: "y" := (alloc (type.zero_val #intT)) in
+        (let: "y" := (mem.alloc (type.zero_val #intT)) in
         let: "$r0" := #(W64 94) in
         do:  ("y" <-[#intT] "$r0");;;
         (if: (![#intT] "y") = #(W64 30)
@@ -413,7 +413,7 @@ Definition ifStmtInitialization : val :=
           (if: (![#uint64T] "x") = #(W64 30)
           then do:  #()
           else do:  #()))))))));;;
-    (let: "y" := (alloc (type.zero_val #uint64T)) in
+    (let: "y" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 10) in
     do:  ("y" <-[#uint64T] "$r0");;;
     (if: (![#uint64T] "x") = #(W64 0)
@@ -430,7 +430,7 @@ Definition typedLiteral : val :=
 (* go: conversions.go:9:6 *)
 Definition literalCast : val :=
   rec: "literalCast" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 2) in
     do:  ("x" <-[#uint64T] "$r0");;;
     return: ((![#uint64T] "x") + #(W64 2))).
@@ -438,15 +438,15 @@ Definition literalCast : val :=
 (* go: conversions.go:15:6 *)
 Definition castInt : val :=
   rec: "castInt" "p" :=
-    exception_do (let: "p" := (alloc "p") in
+    exception_do (let: "p" := (mem.alloc "p") in
     return: (s_to_w64 (let: "$a0" := (![#sliceT] "p") in
      slice.len "$a0"))).
 
 (* go: conversions.go:19:6 *)
 Definition stringToByteSlice : val :=
   rec: "stringToByteSlice" "s" :=
-    exception_do (let: "s" := (alloc "s") in
-    let: "p" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "s" := (mem.alloc "s") in
+    let: "p" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (string.to_bytes (![#stringT] "s")) in
     do:  ("p" <-[#sliceT] "$r0");;;
     return: (![#sliceT] "p")).
@@ -454,8 +454,8 @@ Definition stringToByteSlice : val :=
 (* go: conversions.go:25:6 *)
 Definition byteSliceToString : val :=
   rec: "byteSliceToString" "p" :=
-    exception_do (let: "p" := (alloc "p") in
-    let: "s" := (alloc (type.zero_val #stringT)) in
+    exception_do (let: "p" := (mem.alloc "p") in
+    let: "s" := (mem.alloc (type.zero_val #stringT)) in
     let: "$r0" := (string.from_bytes (![#sliceT] "p")) in
     do:  ("s" <-[#stringT] "$r0");;;
     return: (![#stringT] "s")).
@@ -463,24 +463,24 @@ Definition byteSliceToString : val :=
 (* go: conversions.go:31:6 *)
 Definition stringToStringWrapper : val :=
   rec: "stringToStringWrapper" "s" :=
-    exception_do (let: "s" := (alloc "s") in
+    exception_do (let: "s" := (mem.alloc "s") in
     return: (![#stringT] "s")).
 
 (* go: conversions.go:35:6 *)
 Definition stringWrapperToString : val :=
   rec: "stringWrapperToString" "s" :=
-    exception_do (let: "s" := (alloc "s") in
+    exception_do (let: "s" := (mem.alloc "s") in
     return: (![#stringWrapper] "s")).
 
 (* go: copy.go:3:6 *)
 Definition testCopySimple : val :=
   rec: "testCopySimple" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 10)) in
     do:  ("x" <-[#sliceT] "$r0");;;
     let: "$r0" := #(W8 1) in
     do:  ((slice.elem_ref #byteT (![#sliceT] "x") #(W64 3)) <-[#byteT] "$r0");;;
-    let: "y" := (alloc (type.zero_val #sliceT)) in
+    let: "y" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 10)) in
     do:  ("y" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := (![#sliceT] "y") in
@@ -491,17 +491,17 @@ Definition testCopySimple : val :=
 (* go: copy.go:11:6 *)
 Definition testCopyDifferentLengths : val :=
   rec: "testCopyDifferentLengths" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 15)) in
     do:  ("x" <-[#sliceT] "$r0");;;
     let: "$r0" := #(W8 1) in
     do:  ((slice.elem_ref #byteT (![#sliceT] "x") #(W64 3)) <-[#byteT] "$r0");;;
     let: "$r0" := #(W8 2) in
     do:  ((slice.elem_ref #byteT (![#sliceT] "x") #(W64 12)) <-[#byteT] "$r0");;;
-    let: "y" := (alloc (type.zero_val #sliceT)) in
+    let: "y" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 10)) in
     do:  ("y" <-[#sliceT] "$r0");;;
-    let: "n" := (alloc (type.zero_val #uint64T)) in
+    let: "n" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (s_to_w64 (let: "$a0" := (![#sliceT] "y") in
     let: "$a1" := (![#sliceT] "x") in
     (slice.copy #byteT) "$a0" "$a1")) in
@@ -511,18 +511,18 @@ Definition testCopyDifferentLengths : val :=
 (* go: data_structures.go:7:6 *)
 Definition atomicCreateStub : val :=
   rec: "atomicCreateStub" "dir" "fname" "data" :=
-    exception_do (let: "data" := (alloc "data") in
-    let: "fname" := (alloc "fname") in
-    let: "dir" := (alloc "dir") in
+    exception_do (let: "data" := (mem.alloc "data") in
+    let: "fname" := (mem.alloc "fname") in
+    let: "dir" := (mem.alloc "dir") in
     do:  #()).
 
 (* go: data_structures.go:9:6 *)
 Definition useSlice : val :=
   rec: "useSlice" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 1)) in
     do:  ("s" <-[#sliceT] "$r0");;;
-    let: "s1" := (alloc (type.zero_val #sliceT)) in
+    let: "s1" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "s") in
     let: "$a1" := (![#sliceT] "s") in
     (slice.append #byteT) "$a0" "$a1") in
@@ -535,12 +535,12 @@ Definition useSlice : val :=
 (* go: data_structures.go:15:6 *)
 Definition useSliceIndexing : val :=
   rec: "useSliceIndexing" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #uint64T #(W64 2)) in
     do:  ("s" <-[#sliceT] "$r0");;;
     let: "$r0" := #(W64 2) in
     do:  ((slice.elem_ref #uint64T (![#sliceT] "s") #(W64 1)) <-[#uint64T] "$r0");;;
-    let: "x" := (alloc (type.zero_val #uint64T)) in
+    let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (slice.elem_ref #uint64T (![#sliceT] "s") #(W64 0))) in
     do:  ("x" <-[#uint64T] "$r0");;;
     return: (![#uint64T] "x")).
@@ -548,13 +548,13 @@ Definition useSliceIndexing : val :=
 (* go: data_structures.go:22:6 *)
 Definition useMap : val :=
   rec: "useMap" <> :=
-    exception_do (let: "m" := (alloc (type.zero_val #(mapT uint64T sliceT))) in
+    exception_do (let: "m" := (mem.alloc (type.zero_val #(mapT uint64T sliceT))) in
     let: "$r0" := (map.make #uint64T #sliceT) in
     do:  ("m" <-[#(mapT uint64T sliceT)] "$r0");;;
     let: "$r0" := #slice.nil in
     do:  (map.insert (![#(mapT uint64T sliceT)] "m") #(W64 1) "$r0");;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
-    let: "x" := (alloc (type.zero_val #sliceT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
+    let: "x" := (mem.alloc (type.zero_val #sliceT)) in
     let: ("$ret0", "$ret1") := (map.get (![#(mapT uint64T sliceT)] "m") #(W64 2)) in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
@@ -569,12 +569,12 @@ Definition useMap : val :=
 (* go: data_structures.go:32:6 *)
 Definition usePtr : val :=
   rec: "usePtr" <> :=
-    exception_do (let: "p" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "p" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("p" <-[#ptrT] "$r0");;;
     let: "$r0" := #(W64 1) in
     do:  ((![#ptrT] "p") <-[#uint64T] "$r0");;;
-    let: "x" := (alloc (type.zero_val #uint64T)) in
+    let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] "p")) in
     do:  ("x" <-[#uint64T] "$r0");;;
     let: "$r0" := (![#uint64T] "x") in
@@ -583,22 +583,22 @@ Definition usePtr : val :=
 (* go: data_structures.go:39:6 *)
 Definition iterMapKeysAndValues : val :=
   rec: "iterMapKeysAndValues" "m" :=
-    exception_do (let: "m" := (alloc "m") in
-    let: "sumPtr" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "m" := (mem.alloc "m") in
+    let: "sumPtr" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("sumPtr" <-[#ptrT] "$r0");;;
     let: "$range" := (![#(mapT uint64T uint64T)] "m") in
-    (let: "v" := (alloc (type.zero_val #uint64T)) in
-    let: "k" := (alloc (type.zero_val #uint64T)) in
+    (let: "v" := (mem.alloc (type.zero_val #uint64T)) in
+    let: "k" := (mem.alloc (type.zero_val #uint64T)) in
     map.for_range "$range" (λ: "$key" "value",
       do:  ("v" <-[#uint64T] "$value");;;
       do:  ("k" <-[#uint64T] "$key");;;
-      let: "sum" := (alloc (type.zero_val #uint64T)) in
+      let: "sum" := (mem.alloc (type.zero_val #uint64T)) in
       let: "$r0" := (![#uint64T] (![#ptrT] "sumPtr")) in
       do:  ("sum" <-[#uint64T] "$r0");;;
       let: "$r0" := (((![#uint64T] "sum") + (![#uint64T] "k")) + (![#uint64T] "v")) in
       do:  ((![#ptrT] "sumPtr") <-[#uint64T] "$r0")));;;
-    let: "sum" := (alloc (type.zero_val #uint64T)) in
+    let: "sum" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] "sumPtr")) in
     do:  ("sum" <-[#uint64T] "$r0");;;
     return: (![#uint64T] "sum")).
@@ -606,23 +606,23 @@ Definition iterMapKeysAndValues : val :=
 (* go: data_structures.go:49:6 *)
 Definition iterMapKeys : val :=
   rec: "iterMapKeys" "m" :=
-    exception_do (let: "m" := (alloc "m") in
-    let: "keysSlice" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "m" := (mem.alloc "m") in
+    let: "keysSlice" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #uint64T #(W64 0)) in
     do:  ("keysSlice" <-[#sliceT] "$r0");;;
-    let: "keysRef" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sliceT)) in
+    let: "keysRef" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sliceT)) in
     do:  ("keysRef" <-[#ptrT] "$r0");;;
     let: "$r0" := (![#sliceT] "keysSlice") in
     do:  ((![#ptrT] "keysRef") <-[#sliceT] "$r0");;;
     let: "$range" := (![#(mapT uint64T uint64T)] "m") in
-    (let: "k" := (alloc (type.zero_val #uint64T)) in
+    (let: "k" := (mem.alloc (type.zero_val #uint64T)) in
     map.for_range "$range" (λ: "$key" "value",
       do:  ("k" <-[#uint64T] "$key");;;
-      let: "keys" := (alloc (type.zero_val #sliceT)) in
+      let: "keys" := (mem.alloc (type.zero_val #sliceT)) in
       let: "$r0" := (![#sliceT] (![#ptrT] "keysRef")) in
       do:  ("keys" <-[#sliceT] "$r0");;;
-      let: "newKeys" := (alloc (type.zero_val #sliceT)) in
+      let: "newKeys" := (mem.alloc (type.zero_val #sliceT)) in
       let: "$r0" := (let: "$a0" := (![#sliceT] "keys") in
       let: "$a1" := ((let: "$sl0" := (![#uint64T] "k") in
       slice.literal #uint64T ["$sl0"])) in
@@ -630,7 +630,7 @@ Definition iterMapKeys : val :=
       do:  ("newKeys" <-[#sliceT] "$r0");;;
       let: "$r0" := (![#sliceT] "newKeys") in
       do:  ((![#ptrT] "keysRef") <-[#sliceT] "$r0")));;;
-    let: "keys" := (alloc (type.zero_val #sliceT)) in
+    let: "keys" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (![#sliceT] (![#ptrT] "keysRef")) in
     do:  ("keys" <-[#sliceT] "$r0");;;
     return: (![#sliceT] "keys")).
@@ -638,7 +638,7 @@ Definition iterMapKeys : val :=
 (* go: data_structures.go:62:6 *)
 Definition getRandom : val :=
   rec: "getRandom" <> :=
-    exception_do (let: "r" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "r" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := ((func_call #primitive #"RandomUint64"%go) #()) in
     do:  ("r" <-[#uint64T] "$r0");;;
     return: (![#uint64T] "r")).
@@ -650,8 +650,8 @@ Definition diskWrapper : go_type := structT [
 (* go: disk.go:9:6 *)
 Definition diskArgument : val :=
   rec: "diskArgument" "d" :=
-    exception_do (let: "d" := (alloc "d") in
-    let: "b" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "d" := (mem.alloc "d") in
+    let: "b" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
     (interface.get #"Read"%go (![#disk.Disk] "d")) "$a0") in
     do:  ("b" <-[#sliceT] "$r0");;;
@@ -678,25 +678,25 @@ Definition embedD : go_type := structT [
 (* go: embedded.go:19:17 *)
 Definition embedA__Foo : val :=
   rec: "embedA__Foo" "a" <> :=
-    exception_do (let: "a" := (alloc "a") in
+    exception_do (let: "a" := (mem.alloc "a") in
     return: (#(W64 0))).
 
 (* go: embedded.go:23:17 *)
 Definition embedB__Foo : val :=
   rec: "embedB__Foo" "a" <> :=
-    exception_do (let: "a" := (alloc "a") in
+    exception_do (let: "a" := (mem.alloc "a") in
     return: (#(W64 10))).
 
 (* go: embedded.go:27:18 *)
 Definition embedA__Bar : val :=
   rec: "embedA__Bar" "a" <> :=
-    exception_do (let: "a" := (alloc "a") in
+    exception_do (let: "a" := (mem.alloc "a") in
     return: (#(W64 13))).
 
 (* go: embedded.go:31:18 *)
 Definition embedB__Car : val :=
   rec: "embedB__Car" "a" <> :=
-    exception_do (let: "a" := (alloc "a") in
+    exception_do (let: "a" := (mem.alloc "a") in
     return: (#(W64 14))).
 
 (* go: embedded.go:35:6 *)
@@ -716,16 +716,16 @@ Definition returnEmbedValWithPointer : val :=
 (* go: embedded.go:43:6 *)
 Definition useEmbeddedField : val :=
   rec: "useEmbeddedField" "d" :=
-    exception_do (let: "d" := (alloc "d") in
-    let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "d" := (mem.alloc "d") in
+    let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (struct.field_ref #embedA #"a"%go (struct.field_ref #embedB #"embedA"%go (![#ptrT] (struct.field_ref #embedC #"embedB"%go (struct.field_ref #embedD #"embedC"%go "d")))))) in
     do:  ("x" <-[#uint64T] "$r0");;;
     let: "$r0" := (![#uint64T] (struct.field_ref #embedA #"a"%go (struct.field_ref #embedB #"embedA"%go (![#ptrT] (struct.field_ref #embedC #"embedB"%go (struct.field_ref #embedD #"embedC"%go "d")))))) in
     do:  ("x" <-[#uint64T] "$r0");;;
     let: "$r0" := #(W64 10) in
     do:  ((struct.field_ref #embedA #"a"%go (struct.field_ref #embedB #"embedA"%go (![#ptrT] (struct.field_ref #embedC #"embedB"%go (struct.field_ref #embedD #"embedC"%go "d"))))) <-[#uint64T] "$r0");;;
-    let: "y" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (struct.make #embedD [{
+    let: "y" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (struct.make #embedD [{
       "embedC" ::= type.zero_val #embedC
     }])) in
     do:  ("y" <-[#ptrT] "$r0");;;
@@ -736,7 +736,7 @@ Definition useEmbeddedField : val :=
 (* go: embedded.go:54:6 *)
 Definition useEmbeddedValField : val :=
   rec: "useEmbeddedValField" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (struct.field_get #embedA "a" (struct.field_get #embedB "embedA" ((func_call #unittest.unittest #"returnEmbedVal"%go) #()))) in
     do:  ("x" <-[#uint64T] "$r0");;;
     let: "$r0" := (![#uint64T] (struct.field_ref #embedA #"a"%go (struct.field_ref #embedB #"embedA"%go (struct.field_get #embedC "embedB" (struct.field_get #embedD "embedC" ((func_call #unittest.unittest #"returnEmbedValWithPointer"%go) #())))))) in
@@ -746,13 +746,13 @@ Definition useEmbeddedValField : val :=
 (* go: embedded.go:60:6 *)
 Definition useEmbeddedMethod : val :=
   rec: "useEmbeddedMethod" "d" :=
-    exception_do (let: "d" := (alloc "d") in
+    exception_do (let: "d" := (mem.alloc "d") in
     return: (((method_call #unittest.unittest #"embedD" #"Foo" (![#embedD] "d")) #()) = ((method_call #unittest.unittest #"embedA" #"Foo" (![#embedA] (struct.field_ref #embedB #"embedA"%go (![#ptrT] (struct.field_ref #embedC #"embedB"%go (struct.field_ref #embedD #"embedC"%go "d")))))) #()))).
 
 (* go: embedded.go:64:6 *)
 Definition useEmbeddedMethod2 : val :=
   rec: "useEmbeddedMethod2" "d" :=
-    exception_do (let: "d" := (alloc "d") in
+    exception_do (let: "d" := (mem.alloc "d") in
     do:  ((method_call #unittest.unittest #"embedD" #"Car" (![#embedD] "d")) #());;;
     return: (((method_call #unittest.unittest #"embedD" #"Bar" (![#embedD] "d")) #()) = ((method_call #unittest.unittest #"embedB'ptr" #"Bar" (![#ptrT] (struct.field_ref #embedC #"embedB"%go (struct.field_ref #embedD #"embedC"%go "d")))) #()))).
 
@@ -773,9 +773,9 @@ Definition Enc : go_type := structT [
 (* go: encoding.go:9:15 *)
 Definition Enc__consume : val :=
   rec: "Enc__consume" "e" "n" :=
-    exception_do (let: "e" := (alloc "e") in
-    let: "n" := (alloc "n") in
-    let: "b" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "e" := (mem.alloc "e") in
+    let: "n" := (mem.alloc "n") in
+    let: "b" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$s" := (![#sliceT] (struct.field_ref #Enc #"p"%go (![#ptrT] "e"))) in
     slice.slice #byteT "$s" #(W64 0) (![#uint64T] "n")) in
     do:  ("b" <-[#sliceT] "$r0");;;
@@ -787,8 +787,8 @@ Definition Enc__consume : val :=
 (* go: encoding.go:15:15 *)
 Definition Enc__UInt64 : val :=
   rec: "Enc__UInt64" "e" "x" :=
-    exception_do (let: "e" := (alloc "e") in
-    let: "x" := (alloc "x") in
+    exception_do (let: "e" := (mem.alloc "e") in
+    let: "x" := (mem.alloc "x") in
     do:  (let: "$a0" := (let: "$a0" := #(W64 8) in
     (method_call #unittest.unittest #"Enc'ptr" #"consume" (![#ptrT] "e")) "$a0") in
     let: "$a1" := (![#uint64T] "x") in
@@ -797,8 +797,8 @@ Definition Enc__UInt64 : val :=
 (* go: encoding.go:19:15 *)
 Definition Enc__UInt32 : val :=
   rec: "Enc__UInt32" "e" "x" :=
-    exception_do (let: "e" := (alloc "e") in
-    let: "x" := (alloc "x") in
+    exception_do (let: "e" := (mem.alloc "e") in
+    let: "x" := (mem.alloc "x") in
     do:  (let: "$a0" := (let: "$a0" := #(W64 4) in
     (method_call #unittest.unittest #"Enc'ptr" #"consume" (![#ptrT] "e")) "$a0") in
     let: "$a1" := (![#uint32T] "x") in
@@ -811,9 +811,9 @@ Definition Dec : go_type := structT [
 (* go: encoding.go:27:15 *)
 Definition Dec__consume : val :=
   rec: "Dec__consume" "d" "n" :=
-    exception_do (let: "d" := (alloc "d") in
-    let: "n" := (alloc "n") in
-    let: "b" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "d" := (mem.alloc "d") in
+    let: "n" := (mem.alloc "n") in
+    let: "b" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$s" := (![#sliceT] (struct.field_ref #Dec #"p"%go (![#ptrT] "d"))) in
     slice.slice #byteT "$s" #(W64 0) (![#uint64T] "n")) in
     do:  ("b" <-[#sliceT] "$r0");;;
@@ -825,7 +825,7 @@ Definition Dec__consume : val :=
 (* go: encoding.go:33:15 *)
 Definition Dec__UInt64 : val :=
   rec: "Dec__UInt64" "d" <> :=
-    exception_do (let: "d" := (alloc "d") in
+    exception_do (let: "d" := (mem.alloc "d") in
     return: (let: "$a0" := (let: "$a0" := #(W64 8) in
      (method_call #unittest.unittest #"Dec'ptr" #"consume" (![#ptrT] "d")) "$a0") in
      (func_call #primitive #"UInt64Get"%go) "$a0")).
@@ -833,7 +833,7 @@ Definition Dec__UInt64 : val :=
 (* go: encoding.go:37:15 *)
 Definition Dec__UInt32 : val :=
   rec: "Dec__UInt32" "d" <> :=
-    exception_do (let: "d" := (alloc "d") in
+    exception_do (let: "d" := (mem.alloc "d") in
     return: (let: "$a0" := (let: "$a0" := #(W64 4) in
      (method_call #unittest.unittest #"Dec'ptr" #"consume" (![#ptrT] "d")) "$a0") in
      (func_call #primitive #"UInt32Get"%go) "$a0")).
@@ -841,7 +841,7 @@ Definition Dec__UInt32 : val :=
 (* go: for_range.go:5:6 *)
 Definition forRangeNoBinding : val :=
   rec: "forRangeNoBinding" "x" :=
-    exception_do (let: "x" := (alloc "x") in
+    exception_do (let: "x" := (mem.alloc "x") in
     let: "$range" := (![#sliceT] "x") in
     slice.for_range #stringT "$range" (λ: "$key" "$value",
       do:  (let: "$a0" := ((let: "$sl0" := (interface.make #"slice'"%go (![#sliceT] "x")) in
@@ -851,8 +851,8 @@ Definition forRangeNoBinding : val :=
 (* go: for_range.go:11:6 *)
 Definition forRangeOldVars : val :=
   rec: "forRangeOldVars" "x" :=
-    exception_do (let: "x" := (alloc "x") in
-    let: "y" := (alloc (type.zero_val #stringT)) in
+    exception_do (let: "x" := (mem.alloc "x") in
+    let: "y" := (mem.alloc (type.zero_val #stringT)) in
     let: "$r0" := #"ok"%go in
     do:  ("y" <-[#stringT] "$r0");;;
     let: "$range" := (![#sliceT] "x") in
@@ -887,7 +887,7 @@ Definition bar : val :=
 (* go: higher_order.go:3:6 *)
 Definition TakesFunctionType : val :=
   rec: "TakesFunctionType" "f" :=
-    exception_do (let: "f" := (alloc "f") in
+    exception_do (let: "f" := (mem.alloc "f") in
     do:  ((![#funcT] "f") #())).
 
 Definition Fooer : go_type := interfaceT.
@@ -903,21 +903,21 @@ Definition FooerUser : go_type := structT [
 (* go: interfaces.go:15:25 *)
 Definition concreteFooer__Foo : val :=
   rec: "concreteFooer__Foo" "f" <> :=
-    exception_do (let: "f" := (alloc "f") in
+    exception_do (let: "f" := (mem.alloc "f") in
     do:  #()).
 
 (* go: interfaces.go:18:6 *)
 Definition fooConsumer : val :=
   rec: "fooConsumer" "f" :=
-    exception_do (let: "f" := (alloc "f") in
+    exception_do (let: "f" := (mem.alloc "f") in
     do:  ((interface.get #"Foo"%go (![#Fooer] "f")) #())).
 
 (* go: interfaces.go:22:6 *)
 Definition testAssignConcreteToInterface : val :=
   rec: "testAssignConcreteToInterface" "x" :=
-    exception_do (let: "x" := (alloc "x") in
-    let: "c" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (struct.make #concreteFooer [{
+    exception_do (let: "x" := (mem.alloc "x") in
+    let: "c" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (struct.make #concreteFooer [{
       "a" ::= type.zero_val #uint64T
     }])) in
     do:  ("c" <-[#ptrT] "$r0");;;
@@ -927,14 +927,14 @@ Definition testAssignConcreteToInterface : val :=
 (* go: interfaces.go:27:6 *)
 Definition testPassConcreteToInterfaceArg : val :=
   rec: "testPassConcreteToInterfaceArg" <> :=
-    exception_do (let: "c" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (struct.make #concreteFooer [{
+    exception_do (let: "c" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (struct.make #concreteFooer [{
       "a" ::= type.zero_val #uint64T
     }])) in
     do:  ("c" <-[#ptrT] "$r0");;;
     do:  (let: "$a0" := (interface.make #unittest.unittest #"concreteFooer'ptr" (![#ptrT] "c")) in
     (func_call #unittest.unittest #"fooConsumer"%go) "$a0");;;
-    let: "f" := (alloc (type.zero_val #Fooer)) in
+    let: "f" := (mem.alloc (type.zero_val #Fooer)) in
     let: "$r0" := (interface.make #unittest.unittest #"concreteFooer'ptr" (![#ptrT] "c")) in
     do:  ("f" <-[#Fooer] "$r0");;;
     do:  (let: "$a0" := (![#Fooer] "f") in
@@ -945,27 +945,27 @@ Definition testPassConcreteToInterfaceArg : val :=
 (* go: interfaces.go:37:6 *)
 Definition testPassConcreteToInterfaceArgSpecial : val :=
   rec: "testPassConcreteToInterfaceArgSpecial" <> :=
-    exception_do (let: "c1" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (struct.make #concreteFooer [{
+    exception_do (let: "c1" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (struct.make #concreteFooer [{
       "a" ::= type.zero_val #uint64T
     }])) in
     do:  ("c1" <-[#ptrT] "$r0");;;
-    let: "c2" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (struct.make #concreteFooer [{
+    let: "c2" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (struct.make #concreteFooer [{
       "a" ::= type.zero_val #uint64T
     }])) in
     do:  ("c2" <-[#ptrT] "$r0");;;
-    let: "l" := (alloc (type.zero_val #sliceT)) in
+    let: "l" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := ((let: "$sl0" := (interface.make #unittest.unittest #"concreteFooer'ptr" (![#ptrT] "c1")) in
     let: "$sl1" := (interface.make #unittest.unittest #"concreteFooer'ptr" (![#ptrT] "c2")) in
     slice.literal #Fooer ["$sl0"; "$sl1"])) in
     do:  ("l" <-[#sliceT] "$r0");;;
-    let: "m" := (alloc (type.zero_val #(mapT uint64T Fooer))) in
+    let: "m" := (mem.alloc (type.zero_val #(mapT uint64T Fooer))) in
     let: "$r0" := (map.make #uint64T #Fooer) in
     do:  ("m" <-[#(mapT uint64T Fooer)] "$r0");;;
     let: "$r0" := (interface.make #unittest.unittest #"concreteFooer'ptr" (![#ptrT] "c1")) in
     do:  (map.insert (![#(mapT uint64T Fooer)] "m") #(W64 10) "$r0");;;
-    let: "f" := (alloc (type.zero_val #FooerUser)) in
+    let: "f" := (mem.alloc (type.zero_val #FooerUser)) in
     let: "$r0" := (struct.make #FooerUser [{
       "f" ::= interface.make #unittest.unittest #"concreteFooer'ptr" (![#ptrT] "c1")
     }]) in
@@ -975,16 +975,16 @@ Definition testPassConcreteToInterfaceArgSpecial : val :=
 (* go: interfaces.go:51:6 *)
 Definition takesVarArgsInterface : val :=
   rec: "takesVarArgsInterface" "fs" :=
-    exception_do (let: "fs" := (alloc "fs") in
+    exception_do (let: "fs" := (mem.alloc "fs") in
     do:  ((interface.get #"Foo"%go (![#Fooer] (slice.elem_ref #Fooer (![#sliceT] "fs") #(W64 0)))) #())).
 
 (* go: interfaces.go:55:6 *)
 Definition test : val :=
   rec: "test" <> :=
-    exception_do (do:  (let: "$a0" := ((let: "$sl0" := (interface.make #unittest.unittest #"concreteFooer'ptr" (alloc (struct.make #concreteFooer [{
+    exception_do (do:  (let: "$a0" := ((let: "$sl0" := (interface.make #unittest.unittest #"concreteFooer'ptr" (mem.alloc (struct.make #concreteFooer [{
       "a" ::= type.zero_val #uint64T
     }]))) in
-    let: "$sl1" := (interface.make #unittest.unittest #"concreteFooer'ptr" (alloc (struct.make #concreteFooer [{
+    let: "$sl1" := (interface.make #unittest.unittest #"concreteFooer'ptr" (mem.alloc (struct.make #concreteFooer [{
       "a" ::= type.zero_val #uint64T
     }]))) in
     slice.literal #Fooer ["$sl0"; "$sl1"])) in
@@ -993,7 +993,7 @@ Definition test : val :=
 (* go: interfaces.go:59:6 *)
 Definition returnConcrete : val :=
   rec: "returnConcrete" <> :=
-    exception_do (return: (alloc (struct.make #concreteFooer [{
+    exception_do (return: (mem.alloc (struct.make #concreteFooer [{
        "a" ::= type.zero_val #uint64T
      }]), #(W64 10))).
 
@@ -1002,8 +1002,8 @@ Definition returnConcrete : val :=
    go: interfaces.go:64:6 *)
 Definition testMultiReturn : val :=
   rec: "testMultiReturn" "x" :=
-    exception_do (let: "x" := (alloc "x") in
-    let: "y" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc "x") in
+    let: "y" := (mem.alloc (type.zero_val #uint64T)) in
     let: ("$ret0", "$ret1") := ((func_call #unittest.unittest #"returnConcrete"%go) #()) in
     let: "$r0" := (interface.make #unittest.unittest #"concreteFooer'ptr" "$ret0") in
     let: "$r1" := "$ret1" in
@@ -1014,8 +1014,8 @@ Definition testMultiReturn : val :=
 (* go: interfaces.go:70:6 *)
 Definition testReturnStatment : val :=
   rec: "testReturnStatment" <> :=
-    exception_do (let: "y" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (struct.make #concreteFooer [{
+    exception_do (let: "y" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (struct.make #concreteFooer [{
       "a" ::= type.zero_val #uint64T
     }])) in
     do:  ("y" <-[#ptrT] "$r0");;;
@@ -1024,9 +1024,9 @@ Definition testReturnStatment : val :=
 (* go: interfaces.go:75:6 *)
 Definition testConversionInEq : val :=
   rec: "testConversionInEq" "f" :=
-    exception_do (let: "f" := (alloc "f") in
-    let: "c" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (struct.make #concreteFooer [{
+    exception_do (let: "f" := (mem.alloc "f") in
+    let: "c" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (struct.make #concreteFooer [{
       "a" ::= type.zero_val #uint64T
     }])) in
     do:  ("c" <-[#ptrT] "$r0");;;
@@ -1037,16 +1037,16 @@ Definition testConversionInEq : val :=
 (* go: interfaces.go:82:6 *)
 Definition takeMultiple : val :=
   rec: "takeMultiple" "a" "f" :=
-    exception_do (let: "f" := (alloc "f") in
-    let: "a" := (alloc "a") in
+    exception_do (let: "f" := (mem.alloc "f") in
+    let: "a" := (mem.alloc "a") in
     do:  #()).
 
 (* go: interfaces.go:85:6 *)
 Definition giveMultiple : val :=
   rec: "giveMultiple" <> :=
-    exception_do (return: (#(W64 0), interface.make #unittest.unittest #"concreteFooer'ptr" (alloc (struct.make #concreteFooer [{
+    exception_do (return: (#(W64 0), interface.make #unittest.unittest #"concreteFooer'ptr" (mem.alloc (struct.make #concreteFooer [{
        "a" ::= type.zero_val #uint64T
-     }])), alloc (struct.make #concreteFooer [{
+     }])), mem.alloc (struct.make #concreteFooer [{
        "a" ::= type.zero_val #uint64T
      }]))).
 
@@ -1076,26 +1076,26 @@ Definition concrete1 : go_type := structT [
 (* go: interfaces.go:106:20 *)
 Definition concrete1__Foo : val :=
   rec: "concrete1__Foo" "c" <> :=
-    exception_do (let: "c" := (alloc "c") in
+    exception_do (let: "c" := (mem.alloc "c") in
     do:  #()).
 
 (* go: interfaces.go:109:21 *)
 Definition concrete1__B : val :=
   rec: "concrete1__B" "c" <> :=
-    exception_do (let: "c" := (alloc "c") in
+    exception_do (let: "c" := (mem.alloc "c") in
     do:  #()).
 
 (* go: interfaces.go:112:6 *)
 Definition testPtrMset : val :=
   rec: "testPtrMset" <> :=
-    exception_do (let: "a" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (struct.make #concrete1 [{
+    exception_do (let: "a" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (struct.make #concrete1 [{
     }])) in
     do:  ("a" <-[#ptrT] "$r0");;;
-    let: "p" := (alloc (type.zero_val #PointerInterface)) in
+    let: "p" := (mem.alloc (type.zero_val #PointerInterface)) in
     let: "$r0" := (interface.make #unittest.unittest #"concrete1'ptr" (![#ptrT] "a")) in
     do:  ("p" <-[#PointerInterface] "$r0");;;
-    let: "f" := (alloc (type.zero_val #Fooer)) in
+    let: "f" := (mem.alloc (type.zero_val #Fooer)) in
     let: "$r0" := (interface.make #unittest.unittest #"concrete1" (![#concrete1] (![#ptrT] "a"))) in
     do:  ("f" <-[#Fooer] "$r0");;;
     do:  ((interface.get #"B"%go (![#PointerInterface] "p")) #());;;
@@ -1104,14 +1104,14 @@ Definition testPtrMset : val :=
 (* go: ints.go:3:6 *)
 Definition useInts : val :=
   rec: "useInts" "x" "y" :=
-    exception_do (let: "y" := (alloc "y") in
-    let: "x" := (alloc "x") in
-    let: "z" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "y" := (mem.alloc "y") in
+    let: "x" := (mem.alloc "x") in
+    let: "z" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (u_to_w64 (![#uint32T] "y")) in
     do:  ("z" <-[#uint64T] "$r0");;;
     let: "$r0" := ((![#uint64T] "z") + #(W64 1)) in
     do:  ("z" <-[#uint64T] "$r0");;;
-    let: "y2" := (alloc (type.zero_val #uint32T)) in
+    let: "y2" := (mem.alloc (type.zero_val #uint32T)) in
     let: "$r0" := ((![#uint32T] "y") + #(W32 3)) in
     do:  ("y2" <-[#uint32T] "$r0");;;
     return: (![#uint64T] "z", ![#uint32T] "y2")).
@@ -1188,8 +1188,8 @@ Definition unKeyedLiteral : val :=
 (* go: locks.go:5:6 *)
 Definition useLocks : val :=
   rec: "useLocks" <> :=
-    exception_do (let: "m" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    exception_do (let: "m" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("m" <-[#ptrT] "$r0");;;
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] "m")) #());;;
     do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] "m")) #())).
@@ -1197,10 +1197,10 @@ Definition useLocks : val :=
 (* go: locks.go:11:6 *)
 Definition useCondVar : val :=
   rec: "useCondVar" <> :=
-    exception_do (let: "m" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    exception_do (let: "m" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("m" <-[#ptrT] "$r0");;;
-    let: "c" := (alloc (type.zero_val #ptrT)) in
+    let: "c" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (let: "$a0" := (interface.make #sync #"Mutex'ptr" (![#ptrT] "m")) in
     (func_call #sync #"NewCond"%go) "$a0") in
     do:  ("c" <-[#ptrT] "$r0");;;
@@ -1216,7 +1216,7 @@ Definition hasCondVar : go_type := structT [
 (* go: log_debugging.go:5:6 *)
 Definition ToBeDebugged : val :=
   rec: "ToBeDebugged" "x" :=
-    exception_do (let: "x" := (alloc "x") in
+    exception_do (let: "x" := (mem.alloc "x") in
     do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"starting function"%go) in
     slice.literal #interfaceT ["$sl0"])) in
     (func_call #log #"Println"%go) "$a0");;;
@@ -1241,27 +1241,27 @@ Definition DoNothing : val :=
    go: loops.go:4:6 *)
 Definition DoSomething : val :=
   rec: "DoSomething" "s" :=
-    exception_do (let: "s" := (alloc "s") in
+    exception_do (let: "s" := (mem.alloc "s") in
     do:  #()).
 
 (* go: loops.go:6:6 *)
 Definition standardForLoop : val :=
   rec: "standardForLoop" "s" :=
-    exception_do (let: "s" := (alloc "s") in
-    let: "sumPtr" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "s" := (mem.alloc "s") in
+    let: "sumPtr" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("sumPtr" <-[#ptrT] "$r0");;;
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
       (if: (![#uint64T] "i") < (s_to_w64 (let: "$a0" := (![#sliceT] "s") in
       slice.len "$a0"))
       then
-        let: "sum" := (alloc (type.zero_val #uint64T)) in
+        let: "sum" := (mem.alloc (type.zero_val #uint64T)) in
         let: "$r0" := (![#uint64T] (![#ptrT] "sumPtr")) in
         do:  ("sum" <-[#uint64T] "$r0");;;
-        let: "x" := (alloc (type.zero_val #uint64T)) in
+        let: "x" := (mem.alloc (type.zero_val #uint64T)) in
         let: "$r0" := (![#uint64T] (slice.elem_ref #uint64T (![#sliceT] "s") (![#uint64T] "i"))) in
         do:  ("x" <-[#uint64T] "$r0");;;
         let: "$r0" := ((![#uint64T] "sum") + (![#uint64T] "x")) in
@@ -1271,7 +1271,7 @@ Definition standardForLoop : val :=
         continue: #()
       else do:  #());;;
       break: #()));;;
-    let: "sum" := (alloc (type.zero_val #uint64T)) in
+    let: "sum" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] "sumPtr")) in
     do:  ("sum" <-[#uint64T] "$r0");;;
     return: (![#uint64T] "sum")).
@@ -1279,7 +1279,7 @@ Definition standardForLoop : val :=
 (* go: loops.go:25:6 *)
 Definition conditionalInLoop : val :=
   rec: "conditionalInLoop" <> :=
-    exception_do ((let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do ((let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
@@ -1298,7 +1298,7 @@ Definition conditionalInLoop : val :=
 (* go: loops.go:38:6 *)
 Definition conditionalInLoopElse : val :=
   rec: "conditionalInLoopElse" <> :=
-    exception_do ((let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do ((let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
@@ -1312,7 +1312,7 @@ Definition conditionalInLoopElse : val :=
 (* go: loops.go:49:6 *)
 Definition nestedConditionalInLoopImplicitContinue : val :=
   rec: "nestedConditionalInLoopImplicitContinue" <> :=
-    exception_do ((let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do ((let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
@@ -1329,7 +1329,7 @@ Definition nestedConditionalInLoopImplicitContinue : val :=
 (* go: loops.go:62:6 *)
 Definition ImplicitLoopContinue : val :=
   rec: "ImplicitLoopContinue" <> :=
-    exception_do ((let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do ((let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
@@ -1342,7 +1342,7 @@ Definition ImplicitLoopContinue : val :=
 (* go: loops.go:70:6 *)
 Definition ImplicitLoopContinue2 : val :=
   rec: "ImplicitLoopContinue2" <> :=
-    exception_do ((let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do ((let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
@@ -1356,7 +1356,7 @@ Definition ImplicitLoopContinue2 : val :=
 (* go: loops.go:79:6 *)
 Definition ImplicitLoopContinueAfterIfBreak : val :=
   rec: "ImplicitLoopContinueAfterIfBreak" "i" :=
-    exception_do (let: "i" := (alloc "i") in
+    exception_do (let: "i" := (mem.alloc "i") in
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
       (if: (![#uint64T] "i") > #(W64 0)
       then break: #()
@@ -1365,11 +1365,11 @@ Definition ImplicitLoopContinueAfterIfBreak : val :=
 (* go: loops.go:87:6 *)
 Definition nestedLoops : val :=
   rec: "nestedLoops" <> :=
-    exception_do ((let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do ((let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
-      (let: "j" := (alloc (type.zero_val #uint64T)) in
+      (let: "j" := (mem.alloc (type.zero_val #uint64T)) in
       let: "$r0" := #(W64 0) in
       do:  ("j" <-[#uint64T] "$r0");;;
       (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
@@ -1386,11 +1386,11 @@ Definition nestedLoops : val :=
 (* go: loops.go:101:6 *)
 Definition nestedGoStyleLoops : val :=
   rec: "nestedGoStyleLoops" <> :=
-    exception_do ((let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do ((let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < #(W64 10)); (λ: <>, do:  ("i" <-[#uint64T] ((![#uint64T] "i") + #(W64 1)))) := λ: <>,
-      (let: "j" := (alloc (type.zero_val #uint64T)) in
+      (let: "j" := (mem.alloc (type.zero_val #uint64T)) in
       let: "$r0" := #(W64 0) in
       do:  ("j" <-[#uint64T] "$r0");;;
       (for: (λ: <>, (![#uint64T] "j") < (![#uint64T] "i")); (λ: <>, do:  ("j" <-[#uint64T] ((![#uint64T] "j") + #(W64 1)))) := λ: <>,
@@ -1402,10 +1402,10 @@ Definition nestedGoStyleLoops : val :=
 (* go: loops.go:113:6 *)
 Definition sumSlice : val :=
   rec: "sumSlice" "xs" :=
-    exception_do (let: "xs" := (alloc "xs") in
-    let: "sum" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "xs" := (mem.alloc "xs") in
+    let: "sum" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$range" := (![#sliceT] "xs") in
-    (let: "x" := (alloc (type.zero_val #intT)) in
+    (let: "x" := (mem.alloc (type.zero_val #intT)) in
     slice.for_range #uint64T "$range" (λ: "$key" "$value",
       do:  ("x" <-[#uint64T] "$value");;;
       do:  "$key";;;
@@ -1424,13 +1424,13 @@ Definition breakFromLoop : val :=
 (* go: maps.go:3:6 *)
 Definition IterateMapKeys : val :=
   rec: "IterateMapKeys" "m" "sum" :=
-    exception_do (let: "sum" := (alloc "sum") in
-    let: "m" := (alloc "m") in
+    exception_do (let: "sum" := (mem.alloc "sum") in
+    let: "m" := (mem.alloc "m") in
     let: "$range" := (![#(mapT uint64T uint64T)] "m") in
-    (let: "k" := (alloc (type.zero_val #uint64T)) in
+    (let: "k" := (mem.alloc (type.zero_val #uint64T)) in
     map.for_range "$range" (λ: "$key" "value",
       do:  ("k" <-[#uint64T] "$key");;;
-      let: "oldSum" := (alloc (type.zero_val #uint64T)) in
+      let: "oldSum" := (mem.alloc (type.zero_val #uint64T)) in
       let: "$r0" := (![#uint64T] (![#ptrT] "sum")) in
       do:  ("oldSum" <-[#uint64T] "$r0");;;
       let: "$r0" := ((![#uint64T] "oldSum") + (![#uint64T] "k")) in
@@ -1439,7 +1439,7 @@ Definition IterateMapKeys : val :=
 (* go: maps.go:10:6 *)
 Definition MapSize : val :=
   rec: "MapSize" "m" :=
-    exception_do (let: "m" := (alloc "m") in
+    exception_do (let: "m" := (mem.alloc "m") in
     return: (s_to_w64 (let: "$a0" := (![#(mapT uint64T boolT)] "m") in
      map.len "$a0"))).
 
@@ -1450,15 +1450,15 @@ Definition MapWrapper : go_type := mapT uint64T boolT.
 (* go: maps.go:18:6 *)
 Definition MapTypeAliases : val :=
   rec: "MapTypeAliases" "m1" "m2" :=
-    exception_do (let: "m2" := (alloc "m2") in
-    let: "m1" := (alloc "m1") in
+    exception_do (let: "m2" := (mem.alloc "m2") in
+    let: "m1" := (mem.alloc "m1") in
     let: "$r0" := (Fst (map.get (![#MapWrapper] "m2") #(W64 0))) in
     do:  (map.insert (![#(mapT IntWrapper boolT)] "m1") #(W64 4) "$r0")).
 
 (* go: maps.go:22:6 *)
 Definition StringMap : val :=
   rec: "StringMap" "m" :=
-    exception_do (let: "m" := (alloc "m") in
+    exception_do (let: "m" := (mem.alloc "m") in
     return: (Fst (map.get (![#(mapT stringT uint64T)] "m") #"foo"%go))).
 
 Definition mapElem : go_type := structT [
@@ -1469,7 +1469,7 @@ Definition mapElem : go_type := structT [
 (* go: maps.go:31:6 *)
 Definition mapUpdateField : val :=
   rec: "mapUpdateField" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #(mapT uint64T ptrT))) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #(mapT uint64T ptrT))) in
     let: "$r0" := (map.make #uint64T #ptrT) in
     do:  ("x" <-[#(mapT uint64T ptrT)] "$r0");;;
     let: "$r0" := #(W64 10) in
@@ -1478,15 +1478,15 @@ Definition mapUpdateField : val :=
 (* go: multiple.go:3:6 *)
 Definition returnTwo : val :=
   rec: "returnTwo" "p" :=
-    exception_do (let: "p" := (alloc "p") in
+    exception_do (let: "p" := (mem.alloc "p") in
     return: (#(W64 0), #(W64 0))).
 
 (* go: multiple.go:7:6 *)
 Definition returnTwoWrapper : val :=
   rec: "returnTwoWrapper" "data" :=
-    exception_do (let: "data" := (alloc "data") in
-    let: "b" := (alloc (type.zero_val #uint64T)) in
-    let: "a" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "data" := (mem.alloc "data") in
+    let: "b" := (mem.alloc (type.zero_val #uint64T)) in
+    let: "a" := (mem.alloc (type.zero_val #uint64T)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := (![#sliceT] "data") in
     (func_call #unittest.unittest #"returnTwo"%go) "$a0") in
     let: "$r0" := "$ret0" in
@@ -1498,8 +1498,8 @@ Definition returnTwoWrapper : val :=
 (* go: multiple.go:12:6 *)
 Definition multipleVar : val :=
   rec: "multipleVar" "x" "y" :=
-    exception_do (let: "y" := (alloc "y") in
-    let: "x" := (alloc "x") in
+    exception_do (let: "y" := (mem.alloc "y") in
+    let: "x" := (mem.alloc "x") in
     do:  #()).
 
 (* go: multiple.go:14:6 *)
@@ -1521,7 +1521,7 @@ Definition multipleReturnPassThrough : val :=
 (* go: nil.go:3:6 *)
 Definition AssignNilSlice : val :=
   rec: "AssignNilSlice" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #sliceT #(W64 4)) in
     do:  ("s" <-[#sliceT] "$r0");;;
     let: "$r0" := #slice.nil in
@@ -1530,7 +1530,7 @@ Definition AssignNilSlice : val :=
 (* go: nil.go:8:6 *)
 Definition AssignNilPointer : val :=
   rec: "AssignNilPointer" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #ptrT #(W64 4)) in
     do:  ("s" <-[#sliceT] "$r0");;;
     let: "$r0" := #null in
@@ -1539,7 +1539,7 @@ Definition AssignNilPointer : val :=
 (* go: nil.go:13:6 *)
 Definition CompareSliceToNil : val :=
   rec: "CompareSliceToNil" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT #(W64 0)) in
     do:  ("s" <-[#sliceT] "$r0");;;
     return: ((![#sliceT] "s") ≠ #slice.nil)).
@@ -1547,44 +1547,44 @@ Definition CompareSliceToNil : val :=
 (* go: nil.go:18:6 *)
 Definition ComparePointerToNil : val :=
   rec: "ComparePointerToNil" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("s" <-[#ptrT] "$r0");;;
     return: ((![#ptrT] "s") ≠ #null)).
 
 (* go: operators.go:3:6 *)
 Definition LogicalOperators : val :=
   rec: "LogicalOperators" "b1" "b2" :=
-    exception_do (let: "b2" := (alloc "b2") in
-    let: "b1" := (alloc "b1") in
+    exception_do (let: "b2" := (mem.alloc "b2") in
+    let: "b1" := (mem.alloc "b1") in
     return: (((![#boolT] "b1") && ((![#boolT] "b2") || (![#boolT] "b1"))) && (~ #false))).
 
 (* go: operators.go:7:6 *)
 Definition LogicalAndEqualityOperators : val :=
   rec: "LogicalAndEqualityOperators" "b1" "x" :=
-    exception_do (let: "x" := (alloc "x") in
-    let: "b1" := (alloc "b1") in
+    exception_do (let: "x" := (mem.alloc "x") in
+    let: "b1" := (mem.alloc "b1") in
     return: (((![#uint64T] "x") = #(W64 3)) && ((![#boolT] "b1") = #true))).
 
 (* go: operators.go:11:6 *)
 Definition ArithmeticShifts : val :=
   rec: "ArithmeticShifts" "x" "y" :=
-    exception_do (let: "y" := (alloc "y") in
-    let: "x" := (alloc "x") in
+    exception_do (let: "y" := (mem.alloc "y") in
+    let: "x" := (mem.alloc "x") in
     return: (#(W64 0))).
 
 (* go: operators.go:16:6 *)
 Definition BitwiseOps : val :=
   rec: "BitwiseOps" "x" "y" :=
-    exception_do (let: "y" := (alloc "y") in
-    let: "x" := (alloc "x") in
+    exception_do (let: "y" := (mem.alloc "y") in
+    let: "x" := (mem.alloc "x") in
     return: ((u_to_w64 (![#uint32T] "x")) `or` ((u_to_w64 (u_to_w32 (![#uint64T] "y"))) `and` #(W64 43)))).
 
 (* go: operators.go:20:6 *)
 Definition Comparison : val :=
   rec: "Comparison" "x" "y" :=
-    exception_do (let: "y" := (alloc "y") in
-    let: "x" := (alloc "x") in
+    exception_do (let: "y" := (mem.alloc "y") in
+    let: "x" := (mem.alloc "x") in
     (if: (![#uint64T] "x") < (![#uint64T] "y")
     then return: (#true)
     else do:  #());;;
@@ -1605,7 +1605,7 @@ Definition Comparison : val :=
 (* go: operators.go:39:6 *)
 Definition AssignOps : val :=
   rec: "AssignOps" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("x" <-[#uint64T] ((![#uint64T] "x") + #(W64 3)));;;
     do:  ("x" <-[#uint64T] ((![#uint64T] "x") - #(W64 3)));;;
     do:  ("x" <-[#uint64T] ((![#uint64T] "x") + #(W64 1)));;;
@@ -1614,7 +1614,7 @@ Definition AssignOps : val :=
 (* go: operators.go:47:6 *)
 Definition Negative : val :=
   rec: "Negative" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #int64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #int64T)) in
     let: "$r0" := #(W64 (- 10)) in
     do:  ("x" <-[#int64T] "$r0");;;
     do:  ("x" <-[#int64T] ((![#int64T] "x") + #(W64 3)))).
@@ -1626,7 +1626,7 @@ Definition wrapExternalStruct : go_type := structT [
 (* go: package.go:13:29 *)
 Definition wrapExternalStruct__join : val :=
   rec: "wrapExternalStruct__join" "w" <> :=
-    exception_do (let: "w" := (alloc "w") in
+    exception_do (let: "w" := (mem.alloc "w") in
     do:  ((method_call #std #"JoinHandle'ptr" #"Join" (![#ptrT] (struct.field_ref #wrapExternalStruct #"j"%go "w"))) #())).
 
 (* go: panic.go:3:6 *)
@@ -1638,7 +1638,7 @@ Definition PanicAtTheDisco : val :=
 (* go: proph.go:5:6 *)
 Definition Oracle : val :=
   rec: "Oracle" <> :=
-    exception_do (let: "p" := (alloc (type.zero_val #ptrT)) in
+    exception_do (let: "p" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := ((func_call #primitive #"NewProph"%go) #()) in
     do:  ("p" <-[#ptrT] "$r0");;;
     let: "$r0" := (![#ptrT] "p") in
@@ -1656,13 +1656,13 @@ Definition composite : go_type := structT [
 (* go: reassign.go:8:6 *)
 Definition ReassignVars : val :=
   rec: "ReassignVars" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
-    let: "y" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
+    let: "y" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("y" <-[#uint64T] "$r0");;;
     let: "$r0" := #(W64 3) in
     do:  ("x" <-[#uint64T] "$r0");;;
-    let: "z" := (alloc (type.zero_val #composite)) in
+    let: "z" := (mem.alloc (type.zero_val #composite)) in
     let: "$r0" := (let: "$a" := (![#uint64T] "x") in
     let: "$b" := (![#uint64T] "y") in
     struct.make #composite [{
@@ -1691,7 +1691,7 @@ Definition R : go_type := structT [
 (* go: recursive.go:10:13 *)
 Definition R__recurMethod : val :=
   rec: "R__recurMethod" "r" <> :=
-    exception_do (let: "r" := (alloc "r") in
+    exception_do (let: "r" := (mem.alloc "r") in
     do:  ((method_call #unittest.unittest #"R'ptr" #"recurMethod" (![#ptrT] "r")) #())).
 
 Definition Other : go_type := structT [
@@ -1705,7 +1705,7 @@ Definition RecursiveEmbedded : go_type := structT [
 (* go: recursive.go:22:29 *)
 Definition RecursiveEmbedded__recurEmbeddedMethod : val :=
   rec: "RecursiveEmbedded__recurEmbeddedMethod" "r" <> :=
-    exception_do (let: "r" := (alloc "r") in
+    exception_do (let: "r" := (mem.alloc "r") in
     do:  ((method_call #unittest.unittest #"Other" #"recurEmbeddedMethod" (![#Other] (struct.field_ref #RecursiveEmbedded #"Other"%go (![#ptrT] "r")))) #())).
 
 (* go: renamedImport.go:7:6 *)
@@ -1730,9 +1730,9 @@ Definition DiskSize : expr := #(W64 1000).
    go: replicated_disk.go:12:6 *)
 Definition TwoDiskWrite : val :=
   rec: "TwoDiskWrite" "diskId" "a" "v" :=
-    exception_do (let: "v" := (alloc "v") in
-    let: "a" := (alloc "a") in
-    let: "diskId" := (alloc "diskId") in
+    exception_do (let: "v" := (mem.alloc "v") in
+    let: "a" := (mem.alloc "a") in
+    let: "diskId" := (mem.alloc "diskId") in
     return: (#true)).
 
 (* TwoDiskRead is a dummy function to represent the base layer's disk read
@@ -1740,8 +1740,8 @@ Definition TwoDiskWrite : val :=
    go: replicated_disk.go:17:6 *)
 Definition TwoDiskRead : val :=
   rec: "TwoDiskRead" "diskId" "a" :=
-    exception_do (let: "a" := (alloc "a") in
-    let: "diskId" := (alloc "diskId") in
+    exception_do (let: "a" := (mem.alloc "a") in
+    let: "diskId" := (mem.alloc "diskId") in
     return: (let: "$Value" := #(W64 0) in
      struct.make #Block [{
        "Value" ::= "$Value"
@@ -1753,7 +1753,7 @@ Definition TwoDiskRead : val :=
    go: replicated_disk.go:23:6 *)
 Definition TwoDiskLock : val :=
   rec: "TwoDiskLock" "a" :=
-    exception_do (let: "a" := (alloc "a") in
+    exception_do (let: "a" := (mem.alloc "a") in
     do:  #()).
 
 (* TwoDiskUnlock is a dummy function to represent unlocking an address in the
@@ -1762,17 +1762,17 @@ Definition TwoDiskLock : val :=
    go: replicated_disk.go:27:6 *)
 Definition TwoDiskUnlock : val :=
   rec: "TwoDiskUnlock" "a" :=
-    exception_do (let: "a" := (alloc "a") in
+    exception_do (let: "a" := (mem.alloc "a") in
     do:  #()).
 
 (* go: replicated_disk.go:29:6 *)
 Definition ReplicatedDiskRead : val :=
   rec: "ReplicatedDiskRead" "a" :=
-    exception_do (let: "a" := (alloc "a") in
+    exception_do (let: "a" := (mem.alloc "a") in
     do:  (let: "$a0" := (![#uint64T] "a") in
     (func_call #unittest.unittest #"TwoDiskLock"%go) "$a0");;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
-    let: "v" := (alloc (type.zero_val #Block)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
+    let: "v" := (mem.alloc (type.zero_val #Block)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := Disk1 in
     let: "$a1" := (![#uint64T] "a") in
     (func_call #unittest.unittest #"TwoDiskRead"%go) "$a0" "$a1") in
@@ -1786,7 +1786,7 @@ Definition ReplicatedDiskRead : val :=
       (func_call #unittest.unittest #"TwoDiskUnlock"%go) "$a0");;;
       return: (![#Block] "v")
     else do:  #());;;
-    let: "v2" := (alloc (type.zero_val #Block)) in
+    let: "v2" := (mem.alloc (type.zero_val #Block)) in
     let: ("$ret0", "$ret1") := (let: "$a0" := Disk2 in
     let: "$a1" := (![#uint64T] "a") in
     (func_call #unittest.unittest #"TwoDiskRead"%go) "$a0" "$a1") in
@@ -1801,8 +1801,8 @@ Definition ReplicatedDiskRead : val :=
 (* go: replicated_disk.go:42:6 *)
 Definition ReplicatedDiskWrite : val :=
   rec: "ReplicatedDiskWrite" "a" "v" :=
-    exception_do (let: "v" := (alloc "v") in
-    let: "a" := (alloc "a") in
+    exception_do (let: "v" := (mem.alloc "v") in
+    let: "a" := (mem.alloc "a") in
     do:  (let: "$a0" := (![#uint64T] "a") in
     (func_call #unittest.unittest #"TwoDiskLock"%go) "$a0");;;
     do:  (let: "$a0" := Disk1 in
@@ -1819,15 +1819,15 @@ Definition ReplicatedDiskWrite : val :=
 (* go: replicated_disk.go:49:6 *)
 Definition ReplicatedDiskRecover : val :=
   rec: "ReplicatedDiskRecover" <> :=
-    exception_do ((let: "a" := (alloc (type.zero_val #uint64T)) in
+    exception_do ((let: "a" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("a" <-[#uint64T] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
       (if: (![#uint64T] "a") > DiskSize
       then break: #()
       else do:  #());;;
-      let: "ok" := (alloc (type.zero_val #boolT)) in
-      let: "v" := (alloc (type.zero_val #Block)) in
+      let: "ok" := (mem.alloc (type.zero_val #boolT)) in
+      let: "v" := (mem.alloc (type.zero_val #Block)) in
       let: ("$ret0", "$ret1") := (let: "$a0" := Disk1 in
       let: "$a1" := (![#uint64T] "a") in
       (func_call #unittest.unittest #"TwoDiskRead"%go) "$a0" "$a1") in
@@ -1849,13 +1849,13 @@ Definition ReplicatedDiskRecover : val :=
 (* go: returns.go:3:6 *)
 Definition BasicNamedReturn : val :=
   rec: "BasicNamedReturn" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #stringT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #stringT)) in
     return: (#"ok"%go)).
 
 (* go: returns.go:7:6 *)
 Definition NamedReturn : val :=
   rec: "NamedReturn" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #stringT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #stringT)) in
     let: "$r0" := ((![#stringT] "x") + #"foo"%go) in
     do:  ("x" <-[#stringT] "$r0");;;
     return: (![#stringT] "x")).
@@ -1863,15 +1863,15 @@ Definition NamedReturn : val :=
 (* go: returns.go:12:6 *)
 Definition BasicNamedReturnMany : val :=
   rec: "BasicNamedReturnMany" <> :=
-    exception_do (let: "y" := (alloc (type.zero_val #stringT)) in
-    let: "x" := (alloc (type.zero_val #stringT)) in
+    exception_do (let: "y" := (mem.alloc (type.zero_val #stringT)) in
+    let: "x" := (mem.alloc (type.zero_val #stringT)) in
     return: (#"ok"%go, #"blah"%go)).
 
 (* go: returns.go:16:6 *)
 Definition NamedReturnMany : val :=
   rec: "NamedReturnMany" <> :=
-    exception_do (let: "y" := (alloc (type.zero_val #stringT)) in
-    let: "x" := (alloc (type.zero_val #stringT)) in
+    exception_do (let: "y" := (mem.alloc (type.zero_val #stringT)) in
+    let: "x" := (mem.alloc (type.zero_val #stringT)) in
     let: "$r0" := #"returned"%go in
     do:  ("x" <-[#stringT] "$r0");;;
     let: "$r0" := #"ok"%go in
@@ -1881,10 +1881,10 @@ Definition NamedReturnMany : val :=
 (* go: returns.go:22:6 *)
 Definition NamedReturnOverride : val :=
   rec: "NamedReturnOverride" <> :=
-    exception_do (let: "y" := (alloc (type.zero_val #stringT)) in
-    let: "x" := (alloc (type.zero_val #stringT)) in
+    exception_do (let: "y" := (mem.alloc (type.zero_val #stringT)) in
+    let: "x" := (mem.alloc (type.zero_val #stringT)) in
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
-      let: "x" := (alloc (type.zero_val #stringT)) in
+      let: "x" := (mem.alloc (type.zero_val #stringT)) in
       let: "$r0" := #"unused"%go in
       do:  ("x" <-[#stringT] "$r0");;;
       do:  ("x" <-[#stringT] ((![#stringT] "x") + #"stillUnused"%go));;;
@@ -1898,21 +1898,21 @@ Definition SliceAlias : go_type := sliceT.
 (* go: slices.go:5:6 *)
 Definition sliceOps : val :=
   rec: "sliceOps" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #uint64T #(W64 10)) in
     do:  ("x" <-[#sliceT] "$r0");;;
-    let: "v1" := (alloc (type.zero_val #uint64T)) in
+    let: "v1" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (slice.elem_ref #uint64T (![#sliceT] "x") #(W64 2))) in
     do:  ("v1" <-[#uint64T] "$r0");;;
-    let: "v2" := (alloc (type.zero_val #sliceT)) in
+    let: "v2" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$s" := (![#sliceT] "x") in
     slice.slice #uint64T "$s" #(W64 2) #(W64 3)) in
     do:  ("v2" <-[#sliceT] "$r0");;;
-    let: "v3" := (alloc (type.zero_val #sliceT)) in
+    let: "v3" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$s" := (![#sliceT] "x") in
     slice.slice #uint64T "$s" #(W64 0) #(W64 3)) in
     do:  ("v3" <-[#sliceT] "$r0");;;
-    let: "v4" := (alloc (type.zero_val #ptrT)) in
+    let: "v4" := (mem.alloc (type.zero_val #ptrT)) in
     let: "$r0" := (slice.elem_ref #uint64T (![#sliceT] "x") #(W64 2)) in
     do:  ("v4" <-[#ptrT] "$r0");;;
     return: ((((((![#uint64T] "v1") + (![#uint64T] (slice.elem_ref #uint64T (![#sliceT] "v2") #(W64 0)))) + (![#uint64T] (slice.elem_ref #uint64T (![#sliceT] "v3") #(W64 1)))) + (![#uint64T] (![#ptrT] "v4"))) + (s_to_w64 (let: "$a0" := (![#sliceT] "x") in
@@ -1922,7 +1922,7 @@ Definition sliceOps : val :=
 (* go: slices.go:14:6 *)
 Definition makeSingletonSlice : val :=
   rec: "makeSingletonSlice" "x" :=
-    exception_do (let: "x" := (alloc "x") in
+    exception_do (let: "x" := (mem.alloc "x") in
     return: ((let: "$sl0" := (![#uint64T] "x") in
      slice.literal #uint64T ["$sl0"]))).
 
@@ -1937,8 +1937,8 @@ Definition sliceOfThings : go_type := structT [
 (* go: slices.go:26:25 *)
 Definition sliceOfThings__getThingRef : val :=
   rec: "sliceOfThings__getThingRef" "ts" "i" :=
-    exception_do (let: "ts" := (alloc "ts") in
-    let: "i" := (alloc "i") in
+    exception_do (let: "ts" := (mem.alloc "ts") in
+    let: "i" := (mem.alloc "i") in
     return: (slice.elem_ref #thing (![#sliceT] (struct.field_ref #sliceOfThings #"things"%go "ts")) (![#uint64T] "i"))).
 
 (* go: slices.go:30:6 *)
@@ -1956,15 +1956,15 @@ Definition Skip : val :=
 (* go: spawn.go:10:6 *)
 Definition simpleSpawn : val :=
   rec: "simpleSpawn" <> :=
-    exception_do (let: "l" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    exception_do (let: "l" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("l" <-[#ptrT] "$r0");;;
-    let: "v" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #uint64T)) in
+    let: "v" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("v" <-[#ptrT] "$r0");;;
     let: "$go" := (λ: <>,
       exception_do (do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] "l")) #());;;
-      let: "x" := (alloc (type.zero_val #uint64T)) in
+      let: "x" := (mem.alloc (type.zero_val #uint64T)) in
       let: "$r0" := (![#uint64T] (![#ptrT] "v")) in
       do:  ("x" <-[#uint64T] "$r0");;;
       (if: (![#uint64T] "x") > #(W64 0)
@@ -1981,17 +1981,17 @@ Definition simpleSpawn : val :=
 (* go: spawn.go:26:6 *)
 Definition threadCode : val :=
   rec: "threadCode" "tid" :=
-    exception_do (let: "tid" := (alloc "tid") in
+    exception_do (let: "tid" := (mem.alloc "tid") in
     do:  #()).
 
 (* go: spawn.go:28:6 *)
 Definition loopSpawn : val :=
   rec: "loopSpawn" <> :=
-    exception_do ((let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do ((let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, (![#uint64T] "i") < #(W64 10)); (λ: <>, do:  ("i" <-[#uint64T] ((![#uint64T] "i") + #(W64 1)))) := λ: <>,
-      let: "i" := (alloc (type.zero_val #uint64T)) in
+      let: "i" := (mem.alloc (type.zero_val #uint64T)) in
       let: "$r0" := (![#uint64T] "i") in
       do:  ("i" <-[#uint64T] "$r0");;;
       let: "$go" := (λ: <>,
@@ -1999,7 +1999,7 @@ Definition loopSpawn : val :=
         (func_call #unittest.unittest #"threadCode"%go) "$a0"))
         ) in
       do:  (Fork ("$go" #()))));;;
-    (let: "dummy" := (alloc (type.zero_val #boolT)) in
+    (let: "dummy" := (mem.alloc (type.zero_val #boolT)) in
     let: "$r0" := #true in
     do:  ("dummy" <-[#boolT] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
@@ -2010,13 +2010,13 @@ Definition loopSpawn : val :=
 (* go: strings.go:3:6 *)
 Definition stringAppend : val :=
   rec: "stringAppend" "s" :=
-    exception_do (let: "s" := (alloc "s") in
+    exception_do (let: "s" := (mem.alloc "s") in
     return: ((#"prefix "%go + (![#stringT] "s")) + #" "%go)).
 
 (* go: strings.go:7:6 *)
 Definition stringLength : val :=
   rec: "stringLength" "s" :=
-    exception_do (let: "s" := (alloc "s") in
+    exception_do (let: "s" := (mem.alloc "s") in
     return: (s_to_w64 (let: "$a0" := (![#stringT] "s") in
      StringLength "$a0"))).
 
@@ -2034,18 +2034,18 @@ Definition Point : go_type := structT [
 (* go: struct_method.go:8:16 *)
 Definition Point__Add : val :=
   rec: "Point__Add" "c" "z" :=
-    exception_do (let: "c" := (alloc "c") in
-    let: "z" := (alloc "z") in
+    exception_do (let: "c" := (mem.alloc "c") in
+    let: "z" := (mem.alloc "z") in
     return: (((![#uint64T] (struct.field_ref #Point #"x"%go "c")) + (![#uint64T] (struct.field_ref #Point #"y"%go "c"))) + (![#uint64T] "z"))).
 
 (* go: struct_method.go:12:16 *)
 Definition Point__GetField : val :=
   rec: "Point__GetField" "c" <> :=
-    exception_do (let: "c" := (alloc "c") in
-    let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "c" := (mem.alloc "c") in
+    let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (struct.field_ref #Point #"x"%go "c")) in
     do:  ("x" <-[#uint64T] "$r0");;;
-    let: "y" := (alloc (type.zero_val #uint64T)) in
+    let: "y" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (struct.field_ref #Point #"y"%go "c")) in
     do:  ("y" <-[#uint64T] "$r0");;;
     return: ((![#uint64T] "x") + (![#uint64T] "y"))).
@@ -2053,7 +2053,7 @@ Definition Point__GetField : val :=
 (* go: struct_method.go:18:6 *)
 Definition UseAdd : val :=
   rec: "UseAdd" <> :=
-    exception_do (let: "c" := (alloc (type.zero_val #Point)) in
+    exception_do (let: "c" := (mem.alloc (type.zero_val #Point)) in
     let: "$r0" := (let: "$x" := #(W64 2) in
     let: "$y" := #(W64 3) in
     struct.make #Point [{
@@ -2061,7 +2061,7 @@ Definition UseAdd : val :=
       "y" ::= "$y"
     }]) in
     do:  ("c" <-[#Point] "$r0");;;
-    let: "r" := (alloc (type.zero_val #uint64T)) in
+    let: "r" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := #(W64 4) in
     (method_call #unittest.unittest #"Point" #"Add" (![#Point] "c")) "$a0") in
     do:  ("r" <-[#uint64T] "$r0");;;
@@ -2070,7 +2070,7 @@ Definition UseAdd : val :=
 (* go: struct_method.go:24:6 *)
 Definition UseAddWithLiteral : val :=
   rec: "UseAddWithLiteral" <> :=
-    exception_do (let: "r" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "r" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := #(W64 4) in
     (method_call #unittest.unittest #"Point" #"Add" (let: "$x" := #(W64 2) in
     let: "$y" := #(W64 3) in
@@ -2095,7 +2095,7 @@ Definition S : go_type := structT [
 (* go: struct_pointers.go:14:6 *)
 Definition NewS : val :=
   rec: "NewS" <> :=
-    exception_do (return: (alloc (let: "$a" := #(W64 2) in
+    exception_do (return: (mem.alloc (let: "$a" := #(W64 2) in
      let: "$b" := (let: "$x" := #(W64 1) in
      let: "$y" := #(W64 2) in
      struct.make #TwoInts [{
@@ -2112,52 +2112,52 @@ Definition NewS : val :=
 (* go: struct_pointers.go:22:13 *)
 Definition S__readA : val :=
   rec: "S__readA" "s" <> :=
-    exception_do (let: "s" := (alloc "s") in
+    exception_do (let: "s" := (mem.alloc "s") in
     return: (![#uint64T] (struct.field_ref #S #"a"%go (![#ptrT] "s")))).
 
 (* go: struct_pointers.go:26:13 *)
 Definition S__readB : val :=
   rec: "S__readB" "s" <> :=
-    exception_do (let: "s" := (alloc "s") in
+    exception_do (let: "s" := (mem.alloc "s") in
     return: (![#TwoInts] (struct.field_ref #S #"b"%go (![#ptrT] "s")))).
 
 (* go: struct_pointers.go:30:12 *)
 Definition S__readBVal : val :=
   rec: "S__readBVal" "s" <> :=
-    exception_do (let: "s" := (alloc "s") in
+    exception_do (let: "s" := (mem.alloc "s") in
     return: (![#TwoInts] (struct.field_ref #S #"b"%go "s"))).
 
 (* go: struct_pointers.go:34:13 *)
 Definition S__writeB : val :=
   rec: "S__writeB" "s" "two" :=
-    exception_do (let: "s" := (alloc "s") in
-    let: "two" := (alloc "two") in
+    exception_do (let: "s" := (mem.alloc "s") in
+    let: "two" := (mem.alloc "two") in
     let: "$r0" := (![#TwoInts] "two") in
     do:  ((struct.field_ref #S #"b"%go (![#ptrT] "s")) <-[#TwoInts] "$r0")).
 
 (* go: struct_pointers.go:38:13 *)
 Definition S__negateC : val :=
   rec: "S__negateC" "s" <> :=
-    exception_do (let: "s" := (alloc "s") in
+    exception_do (let: "s" := (mem.alloc "s") in
     let: "$r0" := (~ (![#boolT] (struct.field_ref #S #"c"%go (![#ptrT] "s")))) in
     do:  ((struct.field_ref #S #"c"%go (![#ptrT] "s")) <-[#boolT] "$r0")).
 
 (* go: struct_pointers.go:42:13 *)
 Definition S__refC : val :=
   rec: "S__refC" "s" <> :=
-    exception_do (let: "s" := (alloc "s") in
+    exception_do (let: "s" := (mem.alloc "s") in
     return: (struct.field_ref #S #"c"%go (![#ptrT] "s"))).
 
 (* go: struct_pointers.go:46:6 *)
 Definition localSRef : val :=
   rec: "localSRef" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #S)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #S)) in
     return: (struct.field_ref #S #"b"%go "s")).
 
 (* go: struct_pointers.go:54:6 *)
 Definition setField : val :=
   rec: "setField" <> :=
-    exception_do (let: "s" := (alloc (type.zero_val #S)) in
+    exception_do (let: "s" := (mem.alloc (type.zero_val #S)) in
     let: "$r0" := #(W64 0) in
     do:  ((struct.field_ref #S #"a"%go "s") <-[#uint64T] "$r0");;;
     let: "$r0" := #true in
@@ -2169,15 +2169,15 @@ Definition setField : val :=
    go: synchronization.go:6:6 *)
 Definition DoSomeLocking : val :=
   rec: "DoSomeLocking" "l" :=
-    exception_do (let: "l" := (alloc "l") in
+    exception_do (let: "l" := (mem.alloc "l") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] "l")) #());;;
     do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] "l")) #())).
 
 (* go: synchronization.go:15:6 *)
 Definition makeLock : val :=
   rec: "makeLock" <> :=
-    exception_do (let: "l" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    exception_do (let: "l" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("l" <-[#ptrT] "$r0");;;
     do:  (let: "$a0" := (![#ptrT] "l") in
     (func_call #unittest.unittest #"DoSomeLocking"%go) "$a0")).
@@ -2216,7 +2216,7 @@ Definition UseNamedType : go_type := Timestamp.
 (* go: type_alias.go:11:6 *)
 Definition convertToAlias : val :=
   rec: "convertToAlias" <> :=
-    exception_do (let: "x" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 2) in
     do:  ("x" <-[#uint64T] "$r0");;;
     return: (![#uint64T] "x")).
@@ -2224,9 +2224,9 @@ Definition convertToAlias : val :=
 (* go: varargs.go:3:6 *)
 Definition variadicFunc : val :=
   rec: "variadicFunc" "a" "b" "cs" :=
-    exception_do (let: "cs" := (alloc "cs") in
-    let: "b" := (alloc "b") in
-    let: "a" := (alloc "a") in
+    exception_do (let: "cs" := (mem.alloc "cs") in
+    let: "b" := (mem.alloc "b") in
+    let: "a" := (mem.alloc "a") in
     do:  #()).
 
 (* go: varargs.go:6:6 *)
@@ -2244,7 +2244,7 @@ Definition testVariadicCall : val :=
     let: "$a1" := #"abc"%go in
     let: "$a2" := #slice.nil in
     (func_call #unittest.unittest #"variadicFunc"%go) "$a0" "$a1" "$a2");;;
-    let: "c" := (alloc (type.zero_val #sliceT)) in
+    let: "c" := (mem.alloc (type.zero_val #sliceT)) in
     do:  (let: "$a0" := #(W64 10) in
     let: "$a1" := #"abc"%go in
     let: "$a2" := (![#sliceT] "c") in

--- a/testdata/examples/wal/wal.gold.v
+++ b/testdata/examples/wal/wal.gold.v
@@ -26,8 +26,8 @@ Definition Log : go_type := structT [
 (* go: log.go:25:6 *)
 Definition intToBlock : val :=
   rec: "intToBlock" "a" :=
-    exception_do (let: "a" := (alloc "a") in
-    let: "b" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "a" := (mem.alloc "a") in
+    let: "b" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (slice.make2 #byteT disk.BlockSize) in
     do:  ("b" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := (![#sliceT] "b") in
@@ -38,8 +38,8 @@ Definition intToBlock : val :=
 (* go: log.go:31:6 *)
 Definition blockToInt : val :=
   rec: "blockToInt" "v" :=
-    exception_do (let: "v" := (alloc "v") in
-    let: "a" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "v" := (mem.alloc "v") in
+    let: "a" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "v") in
     (func_call #primitive #"UInt64Get"%go) "$a0") in
     do:  ("a" <-[#uint64T] "$r0");;;
@@ -50,10 +50,10 @@ Definition blockToInt : val :=
    go: log.go:37:6 *)
 Definition New : val :=
   rec: "New" <> :=
-    exception_do (let: "d" := (alloc (type.zero_val #disk.Disk)) in
+    exception_do (let: "d" := (mem.alloc (type.zero_val #disk.Disk)) in
     let: "$r0" := ((func_call #disk #"Get"%go) #()) in
     do:  ("d" <-[#disk.Disk] "$r0");;;
-    let: "diskSize" := (alloc (type.zero_val #uint64T)) in
+    let: "diskSize" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := ((interface.get #"Size"%go (![#disk.Disk] "d")) #()) in
     do:  ("diskSize" <-[#uint64T] "$r0");;;
     (if: (![#uint64T] "diskSize") ≤ logLength
@@ -61,23 +61,23 @@ Definition New : val :=
       do:  (let: "$a0" := (interface.make #""%go #"string"%go #"disk is too small to host log"%go) in
       Panic "$a0")
     else do:  #());;;
-    let: "cache" := (alloc (type.zero_val #(mapT uint64T sliceT))) in
+    let: "cache" := (mem.alloc (type.zero_val #(mapT uint64T sliceT))) in
     let: "$r0" := (map.make #uint64T #sliceT) in
     do:  ("cache" <-[#(mapT uint64T sliceT)] "$r0");;;
-    let: "header" := (alloc (type.zero_val #sliceT)) in
+    let: "header" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
     (func_call #wal.awol #"intToBlock"%go) "$a0") in
     do:  ("header" <-[#sliceT] "$r0");;;
     do:  (let: "$a0" := #(W64 0) in
     let: "$a1" := (![#sliceT] "header") in
     (interface.get #"Write"%go (![#disk.Disk] "d")) "$a0" "$a1");;;
-    let: "lengthPtr" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #uint64T)) in
+    let: "lengthPtr" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("lengthPtr" <-[#ptrT] "$r0");;;
     let: "$r0" := #(W64 0) in
     do:  ((![#ptrT] "lengthPtr") <-[#uint64T] "$r0");;;
-    let: "l" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    let: "l" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("l" <-[#ptrT] "$r0");;;
     return: (let: "$d" := (![#disk.Disk] "d") in
      let: "$cache" := (![#(mapT uint64T sliceT)] "cache") in
@@ -93,13 +93,13 @@ Definition New : val :=
 (* go: log.go:52:14 *)
 Definition Log__lock : val :=
   rec: "Log__lock" "l" <> :=
-    exception_do (let: "l" := (alloc "l") in
+    exception_do (let: "l" := (mem.alloc "l") in
     do:  ((method_call #sync #"Mutex'ptr" #"Lock" (![#ptrT] (struct.field_ref #Log #"l"%go "l"))) #())).
 
 (* go: log.go:56:14 *)
 Definition Log__unlock : val :=
   rec: "Log__unlock" "l" <> :=
-    exception_do (let: "l" := (alloc "l") in
+    exception_do (let: "l" := (mem.alloc "l") in
     do:  ((method_call #sync #"Mutex'ptr" #"Unlock" (![#ptrT] (struct.field_ref #Log #"l"%go "l"))) #())).
 
 (* BeginTxn allocates space for a new transaction in the log.
@@ -109,9 +109,9 @@ Definition Log__unlock : val :=
    go: log.go:63:14 *)
 Definition Log__BeginTxn : val :=
   rec: "Log__BeginTxn" "l" <> :=
-    exception_do (let: "l" := (alloc "l") in
+    exception_do (let: "l" := (mem.alloc "l") in
     do:  ((method_call #wal.awol #"Log" #"lock" (![#Log] "l")) #());;;
-    let: "length" := (alloc (type.zero_val #uint64T)) in
+    let: "length" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] (struct.field_ref #Log #"length"%go "l"))) in
     do:  ("length" <-[#uint64T] "$r0");;;
     (if: (![#uint64T] "length") = #(W64 0)
@@ -129,11 +129,11 @@ Definition Log__BeginTxn : val :=
    go: log.go:77:14 *)
 Definition Log__Read : val :=
   rec: "Log__Read" "l" "a" :=
-    exception_do (let: "l" := (alloc "l") in
-    let: "a" := (alloc "a") in
+    exception_do (let: "l" := (mem.alloc "l") in
+    let: "a" := (mem.alloc "a") in
     do:  ((method_call #wal.awol #"Log" #"lock" (![#Log] "l")) #());;;
-    let: "ok" := (alloc (type.zero_val #boolT)) in
-    let: "v" := (alloc (type.zero_val #sliceT)) in
+    let: "ok" := (mem.alloc (type.zero_val #boolT)) in
+    let: "v" := (mem.alloc (type.zero_val #sliceT)) in
     let: ("$ret0", "$ret1") := (map.get (![#(mapT uint64T sliceT)] (struct.field_ref #Log #"cache"%go "l")) (![#uint64T] "a")) in
     let: "$r0" := "$ret0" in
     let: "$r1" := "$ret1" in
@@ -145,7 +145,7 @@ Definition Log__Read : val :=
       return: (![#sliceT] "v")
     else do:  #());;;
     do:  ((method_call #wal.awol #"Log" #"unlock" (![#Log] "l")) #());;;
-    let: "dv" := (alloc (type.zero_val #sliceT)) in
+    let: "dv" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (logLength + (![#uint64T] "a")) in
     (interface.get #"Read"%go (![#disk.Disk] (struct.field_ref #Log #"d"%go "l"))) "$a0") in
     do:  ("dv" <-[#sliceT] "$r0");;;
@@ -154,8 +154,8 @@ Definition Log__Read : val :=
 (* go: log.go:90:14 *)
 Definition Log__Size : val :=
   rec: "Log__Size" "l" <> :=
-    exception_do (let: "l" := (alloc "l") in
-    let: "sz" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "l" := (mem.alloc "l") in
+    let: "sz" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := ((interface.get #"Size"%go (![#disk.Disk] (struct.field_ref #Log #"d"%go "l"))) #()) in
     do:  ("sz" <-[#uint64T] "$r0");;;
     return: ((![#uint64T] "sz") - logLength)).
@@ -165,11 +165,11 @@ Definition Log__Size : val :=
    go: log.go:97:14 *)
 Definition Log__Write : val :=
   rec: "Log__Write" "l" "a" "v" :=
-    exception_do (let: "l" := (alloc "l") in
-    let: "v" := (alloc "v") in
-    let: "a" := (alloc "a") in
+    exception_do (let: "l" := (mem.alloc "l") in
+    let: "v" := (mem.alloc "v") in
+    let: "a" := (mem.alloc "a") in
     do:  ((method_call #wal.awol #"Log" #"lock" (![#Log] "l")) #());;;
-    let: "length" := (alloc (type.zero_val #uint64T)) in
+    let: "length" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] (struct.field_ref #Log #"length"%go "l"))) in
     do:  ("length" <-[#uint64T] "$r0");;;
     (if: (![#uint64T] "length") ≥ MaxTxnWrites
@@ -177,11 +177,11 @@ Definition Log__Write : val :=
       do:  (let: "$a0" := (interface.make #""%go #"string"%go #"transaction is at capacity"%go) in
       Panic "$a0")
     else do:  #());;;
-    let: "aBlock" := (alloc (type.zero_val #sliceT)) in
+    let: "aBlock" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#uint64T] "a") in
     (func_call #wal.awol #"intToBlock"%go) "$a0") in
     do:  ("aBlock" <-[#sliceT] "$r0");;;
-    let: "nextAddr" := (alloc (type.zero_val #uint64T)) in
+    let: "nextAddr" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (#(W64 1) + (#(W64 2) * (![#uint64T] "length"))) in
     do:  ("nextAddr" <-[#uint64T] "$r0");;;
     do:  (let: "$a0" := (![#uint64T] "nextAddr") in
@@ -201,13 +201,13 @@ Definition Log__Write : val :=
    go: log.go:113:14 *)
 Definition Log__Commit : val :=
   rec: "Log__Commit" "l" <> :=
-    exception_do (let: "l" := (alloc "l") in
+    exception_do (let: "l" := (mem.alloc "l") in
     do:  ((method_call #wal.awol #"Log" #"lock" (![#Log] "l")) #());;;
-    let: "length" := (alloc (type.zero_val #uint64T)) in
+    let: "length" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] (struct.field_ref #Log #"length"%go "l"))) in
     do:  ("length" <-[#uint64T] "$r0");;;
     do:  ((method_call #wal.awol #"Log" #"unlock" (![#Log] "l")) #());;;
-    let: "header" := (alloc (type.zero_val #sliceT)) in
+    let: "header" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#uint64T] "length") in
     (func_call #wal.awol #"intToBlock"%go) "$a0") in
     do:  ("header" <-[#sliceT] "$r0");;;
@@ -218,20 +218,20 @@ Definition Log__Commit : val :=
 (* go: log.go:122:6 *)
 Definition getLogEntry : val :=
   rec: "getLogEntry" "d" "logOffset" :=
-    exception_do (let: "logOffset" := (alloc "logOffset") in
-    let: "d" := (alloc "d") in
-    let: "diskAddr" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "logOffset" := (mem.alloc "logOffset") in
+    let: "d" := (mem.alloc "d") in
+    let: "diskAddr" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (#(W64 1) + (#(W64 2) * (![#uint64T] "logOffset"))) in
     do:  ("diskAddr" <-[#uint64T] "$r0");;;
-    let: "aBlock" := (alloc (type.zero_val #sliceT)) in
+    let: "aBlock" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := (![#uint64T] "diskAddr") in
     (interface.get #"Read"%go (![#disk.Disk] "d")) "$a0") in
     do:  ("aBlock" <-[#sliceT] "$r0");;;
-    let: "a" := (alloc (type.zero_val #uint64T)) in
+    let: "a" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "aBlock") in
     (func_call #wal.awol #"blockToInt"%go) "$a0") in
     do:  ("a" <-[#uint64T] "$r0");;;
-    let: "v" := (alloc (type.zero_val #sliceT)) in
+    let: "v" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := ((![#uint64T] "diskAddr") + #(W64 1)) in
     (interface.get #"Read"%go (![#disk.Disk] "d")) "$a0") in
     do:  ("v" <-[#sliceT] "$r0");;;
@@ -242,16 +242,16 @@ Definition getLogEntry : val :=
    go: log.go:131:6 *)
 Definition applyLog : val :=
   rec: "applyLog" "d" "length" :=
-    exception_do (let: "length" := (alloc "length") in
-    let: "d" := (alloc "d") in
-    (let: "i" := (alloc (type.zero_val #uint64T)) in
+    exception_do (let: "length" := (mem.alloc "length") in
+    let: "d" := (mem.alloc "d") in
+    (let: "i" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := #(W64 0) in
     do:  ("i" <-[#uint64T] "$r0");;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
       (if: (![#uint64T] "i") < (![#uint64T] "length")
       then
-        let: "v" := (alloc (type.zero_val #sliceT)) in
-        let: "a" := (alloc (type.zero_val #uint64T)) in
+        let: "v" := (mem.alloc (type.zero_val #sliceT)) in
+        let: "a" := (mem.alloc (type.zero_val #uint64T)) in
         let: ("$ret0", "$ret1") := (let: "$a0" := (![#disk.Disk] "d") in
         let: "$a1" := (![#uint64T] "i") in
         (func_call #wal.awol #"getLogEntry"%go) "$a0" "$a1") in
@@ -271,8 +271,8 @@ Definition applyLog : val :=
 (* go: log.go:142:6 *)
 Definition clearLog : val :=
   rec: "clearLog" "d" :=
-    exception_do (let: "d" := (alloc "d") in
-    let: "header" := (alloc (type.zero_val #sliceT)) in
+    exception_do (let: "d" := (mem.alloc "d") in
+    let: "header" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
     (func_call #wal.awol #"intToBlock"%go) "$a0") in
     do:  ("header" <-[#sliceT] "$r0");;;
@@ -287,9 +287,9 @@ Definition clearLog : val :=
    go: log.go:150:14 *)
 Definition Log__Apply : val :=
   rec: "Log__Apply" "l" <> :=
-    exception_do (let: "l" := (alloc "l") in
+    exception_do (let: "l" := (mem.alloc "l") in
     do:  ((method_call #wal.awol #"Log" #"lock" (![#Log] "l")) #());;;
-    let: "length" := (alloc (type.zero_val #uint64T)) in
+    let: "length" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (![#uint64T] (![#ptrT] (struct.field_ref #Log #"length"%go "l"))) in
     do:  ("length" <-[#uint64T] "$r0");;;
     do:  (let: "$a0" := (![#disk.Disk] (struct.field_ref #Log #"d"%go "l")) in
@@ -306,14 +306,14 @@ Definition Log__Apply : val :=
    go: log.go:163:6 *)
 Definition Open : val :=
   rec: "Open" <> :=
-    exception_do (let: "d" := (alloc (type.zero_val #disk.Disk)) in
+    exception_do (let: "d" := (mem.alloc (type.zero_val #disk.Disk)) in
     let: "$r0" := ((func_call #disk #"Get"%go) #()) in
     do:  ("d" <-[#disk.Disk] "$r0");;;
-    let: "header" := (alloc (type.zero_val #sliceT)) in
+    let: "header" := (mem.alloc (type.zero_val #sliceT)) in
     let: "$r0" := (let: "$a0" := #(W64 0) in
     (interface.get #"Read"%go (![#disk.Disk] "d")) "$a0") in
     do:  ("header" <-[#sliceT] "$r0");;;
-    let: "length" := (alloc (type.zero_val #uint64T)) in
+    let: "length" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$r0" := (let: "$a0" := (![#sliceT] "header") in
     (func_call #wal.awol #"blockToInt"%go) "$a0") in
     do:  ("length" <-[#uint64T] "$r0");;;
@@ -322,16 +322,16 @@ Definition Open : val :=
     (func_call #wal.awol #"applyLog"%go) "$a0" "$a1");;;
     do:  (let: "$a0" := (![#disk.Disk] "d") in
     (func_call #wal.awol #"clearLog"%go) "$a0");;;
-    let: "cache" := (alloc (type.zero_val #(mapT uint64T sliceT))) in
+    let: "cache" := (mem.alloc (type.zero_val #(mapT uint64T sliceT))) in
     let: "$r0" := (map.make #uint64T #sliceT) in
     do:  ("cache" <-[#(mapT uint64T sliceT)] "$r0");;;
-    let: "lengthPtr" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #uint64T)) in
+    let: "lengthPtr" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #uint64T)) in
     do:  ("lengthPtr" <-[#ptrT] "$r0");;;
     let: "$r0" := #(W64 0) in
     do:  ((![#ptrT] "lengthPtr") <-[#uint64T] "$r0");;;
-    let: "l" := (alloc (type.zero_val #ptrT)) in
-    let: "$r0" := (alloc (type.zero_val #sync.Mutex)) in
+    let: "l" := (mem.alloc (type.zero_val #ptrT)) in
+    let: "$r0" := (mem.alloc (type.zero_val #sync.Mutex)) in
     do:  ("l" <-[#ptrT] "$r0");;;
     return: (let: "$d" := (![#disk.Disk] "d") in
      let: "$cache" := (![#(mapT uint64T sliceT)] "cache") in


### PR DESCRIPTION
Avoids referring to a package or function named `alloc`.