### PR TITLE
Use pkg_path.pkg for pkg_imported_pkgs

### DIFF
--- a/testdata/examples/append_log/append_log.gold.v
+++ b/testdata/examples/append_log/append_log.gold.v
@@ -200,7 +200,7 @@ Definition msets' : list (go_string * (list (go_string * val))) := [("Log"%go, [
     pkg_vars := vars';
     pkg_functions := functions';
     pkg_msets := msets';
-    pkg_imported_pkgs := [sync; marshal; disk];
+    pkg_imported_pkgs := [sync.sync; marshal.marshal; disk.disk];
   |}.
 
 Definition initialize' : val :=

--- a/testdata/examples/async/async.gold.v
+++ b/testdata/examples/async/async.gold.v
@@ -38,7 +38,7 @@ Definition msets' : list (go_string * (list (go_string * val))) := [].
     pkg_vars := vars';
     pkg_functions := functions';
     pkg_msets := msets';
-    pkg_imported_pkgs := [async_disk];
+    pkg_imported_pkgs := [async_disk.async_disk];
   |}.
 
 Definition initialize' : val :=

--- a/testdata/examples/externalglobals/externalglobals.gold.v
+++ b/testdata/examples/externalglobals/externalglobals.gold.v
@@ -26,7 +26,7 @@ Definition msets' : list (go_string * (list (go_string * val))) := [].
     pkg_vars := vars';
     pkg_functions := functions';
     pkg_msets := msets';
-    pkg_imported_pkgs := [unittest];
+    pkg_imported_pkgs := [unittest.unittest];
   |}.
 
 Definition initialize' : val :=

--- a/testdata/examples/import/import.gold.v
+++ b/testdata/examples/import/import.gold.v
@@ -20,7 +20,7 @@ Definition msets' : list (go_string * (list (go_string * val))) := [].
     pkg_vars := vars';
     pkg_functions := functions';
     pkg_msets := msets';
-    pkg_imported_pkgs := [atomic];
+    pkg_imported_pkgs := [atomic.atomic];
   |}.
 
 Definition initialize' : val :=

--- a/testdata/examples/logging2/logging2.gold.v
+++ b/testdata/examples/logging2/logging2.gold.v
@@ -409,7 +409,7 @@ Definition msets' : list (go_string * (list (go_string * val))) := [("Log"%go, [
     pkg_vars := vars';
     pkg_functions := functions';
     pkg_msets := msets';
-    pkg_imported_pkgs := [primitive; disk; sync];
+    pkg_imported_pkgs := [primitive.primitive; disk.disk; sync.sync];
   |}.
 
 Definition initialize' : val :=

--- a/testdata/examples/semantics/semantics.gold.v
+++ b/testdata/examples/semantics/semantics.gold.v
@@ -2917,7 +2917,7 @@ Definition msets' : list (go_string * (list (go_string * val))) := [("unit"%go, 
     pkg_vars := vars';
     pkg_functions := functions';
     pkg_msets := msets';
-    pkg_imported_pkgs := [primitive; sync; disk];
+    pkg_imported_pkgs := [primitive.primitive; sync.sync; disk.disk];
   |}.
 
 Definition initialize' : val :=

--- a/testdata/examples/simpledb/simpledb.gold.v
+++ b/testdata/examples/simpledb/simpledb.gold.v
@@ -1032,7 +1032,7 @@ Definition msets' : list (go_string * (list (go_string * val))) := [("Table"%go,
     pkg_vars := vars';
     pkg_functions := functions';
     pkg_msets := msets';
-    pkg_imported_pkgs := [sync; primitive; filesys; marshal];
+    pkg_imported_pkgs := [sync.sync; primitive.primitive; filesys.filesys; marshal.marshal];
   |}.
 
 Definition initialize' : val :=

--- a/testdata/examples/unittest/unittest.gold.v
+++ b/testdata/examples/unittest/unittest.gold.v
@@ -2323,13 +2323,14 @@ Definition msets' : list (go_string * (list (go_string * val))) := [("Foo"%go, [
     pkg_vars := vars';
     pkg_functions := functions';
     pkg_msets := msets';
-    pkg_imported_pkgs := [fmt; sync; primitive; disk; log; std];
+    pkg_imported_pkgs := [fmt.fmt; sync.sync; primitive.primitive; disk.disk; log.log; std.std; fmt.fmt];
   |}.
 
 Definition initialize' : val :=
   rec: "initialize'" <> :=
     globals.package_init unittest.unittest (λ: <>,
-      exception_do (do:  std.initialize';;;
+      exception_do (do:  fmt.initialize';;;
+      do:  std.initialize';;;
       do:  log.initialize';;;
       do:  disk.initialize';;;
       do:  primitive.initialize';;;

--- a/testdata/examples/wal/wal.gold.v
+++ b/testdata/examples/wal/wal.gold.v
@@ -371,7 +371,7 @@ Definition msets' : list (go_string * (list (go_string * val))) := [("Log"%go, [
     pkg_vars := vars';
     pkg_functions := functions';
     pkg_msets := msets';
-    pkg_imported_pkgs := [sync; primitive; disk];
+    pkg_imported_pkgs := [sync.sync; primitive.primitive; disk.disk];
   |}.
 
 Definition initialize' : val :=


### PR DESCRIPTION
Followup to #74 and #78: needed to ensure an identifier like `message` refers to the local imported package rather than the name exported by grove_ffi.