### PR TITLE
Fixed some bugs for chan.select translation

### DIFF
--- a/goose.go
+++ b/goose.go
@@ -2513,7 +2513,7 @@ func (ctx *Ctx) selectStmt(s *ast.SelectStmt, cont glang.Expr) (expr glang.Expr)
 	}
 
 	expr = glang.NewCallExpr(glang.GallinaIdent("chan.select"), ops, def)
-	expr = glang.NewDoSeq(expr, cont)
+	expr = glang.SeqExpr{Expr: expr, Cont: cont}
 	return
 }
 

--- a/goose.go
+++ b/goose.go
@@ -2441,24 +2441,24 @@ func (ctx *Ctx) deferStmt(s *ast.DeferStmt, cont glang.Expr) (expr glang.Expr) {
 }
 
 func (ctx *Ctx) selectStmt(s *ast.SelectStmt, cont glang.Expr) (expr glang.Expr) {
-	var sends glang.ListExpr
-	var recvs glang.ListExpr
-	var def glang.Expr = glang.NewCallExpr(glang.GallinaIdent("InjLV"), glang.Tt)
+	var ops glang.ListExpr
+	var def glang.Expr = glang.GallinaIdent("chan.select_no_default")
 
 	// build up select statement itself
 	for _, s := range s.Body.List {
 		s := s.(*ast.CommClause)
 		if s.Comm == nil {
-			def = glang.NewCallExpr(glang.GallinaIdent("InjR"), glang.FuncLit{Body: ctx.stmtList(s.Body, nil)})
-		} else if _, ok := s.Comm.(*ast.SendStmt); ok {
-			sendIndex := len(sends)
-			sends = append(sends, glang.TupleExpr{
-				glang.IdentExpr(fmt.Sprintf("$sendVal%d", sendIndex)),
-				glang.IdentExpr(fmt.Sprintf("$sendChan%d", sendIndex)),
+			def =
+				glang.NewCallExpr(glang.GallinaIdent("chan.select_default"), glang.FuncLit{Body: ctx.stmtList(s.Body, nil)})
+		} else if c, ok := s.Comm.(*ast.SendStmt); ok {
+			ops = append(ops, glang.NewCallExpr(
+				glang.GallinaIdent("chan.select_send"),
+				ctx.expr(c.Value),
+				ctx.expr(c.Chan),
 				glang.FuncLit{Body: ctx.stmtList(s.Body, nil)},
-			})
+			))
 		} else { // must be a receive stmt
-			recvIndex := len(recvs)
+			var recvChan glang.Expr
 			body := ctx.stmtList(s.Body, nil)
 
 			// want to figure out the first statment to run in the body
@@ -2468,12 +2468,13 @@ func (ctx *Ctx) selectStmt(s *ast.SelectStmt, cont glang.Expr) (expr glang.Expr)
 				if recvExpr.Op != token.ARROW {
 					ctx.nope(comm.X, "expected recv statement")
 				}
-				// nothing to run in the body
+				recvChan = ctx.expr(recvExpr.X)
+				// nothing extra to run in the body
 			case *ast.AssignStmt:
 				// XXX: replace the RHS in the assignment statement with an
 				// ident, so we can put this straight in the the body list
 				if len(comm.Rhs) != 1 {
-					ctx.unsupported(comm, "expected a single receive operation on RHS")
+					ctx.nope(comm, "expected a single receive operation on RHS")
 				}
 				var rhs ast.Expr = comm.Rhs[0]
 				for {
@@ -2487,6 +2488,7 @@ func (ctx *Ctx) selectStmt(s *ast.SelectStmt, cont glang.Expr) (expr glang.Expr)
 				if recvExpr.Op != token.ARROW {
 					ctx.nope(comm.Rhs[0], "expected recv statement")
 				}
+				recvChan = ctx.expr(recvExpr.X)
 
 				// XXX: create a new AST node and enough typing information for
 				// an assignStmt to translate.
@@ -2503,14 +2505,14 @@ func (ctx *Ctx) selectStmt(s *ast.SelectStmt, cont glang.Expr) (expr glang.Expr)
 				ctx.unsupported(s.Comm, "unexpected statement in select clause")
 			}
 
-			recvs = append(recvs, glang.TupleExpr{
-				glang.IdentExpr(fmt.Sprintf("$recvChan%d", recvIndex)),
+			ops = append(ops, glang.NewCallExpr(glang.GallinaIdent("chan.select_receive"),
+				recvChan,
 				glang.FuncLit{Args: []glang.Binder{{Name: "$recvVal"}}, Body: body},
-			})
+			))
 		}
 	}
 
-	expr = glang.NewCallExpr(glang.GallinaIdent("chan.select"), sends, recvs, def)
+	expr = glang.NewCallExpr(glang.GallinaIdent("chan.select"), ops, def)
 	expr = glang.NewDoSeq(expr, cont)
 	return
 }

--- a/testdata/examples/unittest/unittest.gold.v
+++ b/testdata/examples/unittest/unittest.gold.v
@@ -142,7 +142,7 @@ Definition chanSelect : val :=
     let: "c" := (mem.alloc (type.zero_val #(chanT intT))) in
     let: "i2" := (mem.alloc (type.zero_val #intT)) in
     let: "i1" := (mem.alloc (type.zero_val #intT)) in
-    do:  (chan.select [chan.select_receive (![#(chanT intT)] "c3") (λ: "$recvVal",
+    chan.select [chan.select_receive (![#(chanT intT)] "c3") (λ: "$recvVal",
        do:  #()
        ); chan.select_receive (![#(chanT intT)] "c1") (λ: "$recvVal",
        let: "$r0" := (Fst "$recvVal") in
@@ -190,14 +190,14 @@ Definition chanSelect : val :=
       "%go) in
       slice.literal #interfaceT ["$sl0"])) in
       (func_call #fmt.fmt #"Print"%go) "$a0")
-      )));;;
+      ));;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
-      do:  (chan.select [chan.select_send #(W64 0) (![#(chanT intT)] "c") (λ: <>,
+      chan.select [chan.select_send #(W64 0) (![#(chanT intT)] "c") (λ: <>,
          do:  #()
          ); chan.select_send #(W64 1) (![#(chanT intT)] "c") (λ: <>,
          do:  #()
-         )] chan.select_no_default));;;
-    do:  (chan.select [] chan.select_no_default)).
+         )] chan.select_no_default);;;
+    chan.select [] chan.select_no_default).
 
 (* go: chan.go:59:6 *)
 Definition chanDirectional : val :=

--- a/testdata/examples/unittest/unittest.gold.v
+++ b/testdata/examples/unittest/unittest.gold.v
@@ -142,62 +142,62 @@ Definition chanSelect : val :=
     let: "c" := (mem.alloc (type.zero_val #(chanT intT))) in
     let: "i2" := (mem.alloc (type.zero_val #intT)) in
     let: "i1" := (mem.alloc (type.zero_val #intT)) in
-    do:  (chan.select [("$sendVal0", "$sendChan0", (λ: <>,
-        do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"sent "%go) in
-        let: "$sl1" := (interface.make #""%go #"int"%go (![#intT] "i2")) in
-        let: "$sl2" := (interface.make #""%go #"string"%go #" to c2
-        "%go) in
-        slice.literal #interfaceT ["$sl0"; "$sl1"; "$sl2"])) in
-        (func_call #fmt.fmt #"Print"%go) "$a0")
-        ))] [("$recvChan0", (λ: "$recvVal",
-        do:  #()
-        )); ("$recvChan1", (λ: "$recvVal",
-        let: "$r0" := (Fst "$recvVal") in
-        do:  ("i1" <-[#intT] "$r0");;;
-        do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"received "%go) in
-        let: "$sl1" := (interface.make #""%go #"int"%go (![#intT] "i1")) in
-        let: "$sl2" := (interface.make #""%go #"string"%go #" from c1
-        "%go) in
-        slice.literal #interfaceT ["$sl0"; "$sl1"; "$sl2"])) in
-        (func_call #fmt.fmt #"Print"%go) "$a0")
-        )); ("$recvChan2", (λ: "$recvVal",
-        let: "ok" := (mem.alloc (type.zero_val #boolT)) in
-        let: "i3" := (mem.alloc (type.zero_val #intT)) in
-        let: ("$ret0", "$ret1") := "$recvVal" in
-        let: "$r0" := "$ret0" in
-        let: "$r1" := "$ret1" in
-        do:  ("i3" <-[#intT] "$r0");;;
-        do:  ("ok" <-[#boolT] "$r1");;;
-        (if: ![#boolT] "ok"
-        then
-          do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"received "%go) in
-          let: "$sl1" := (interface.make #""%go #"int"%go (![#intT] "i3")) in
-          let: "$sl2" := (interface.make #""%go #"string"%go #" from c3
-          "%go) in
-          slice.literal #interfaceT ["$sl0"; "$sl1"; "$sl2"])) in
-          (func_call #fmt.fmt #"Print"%go) "$a0")
-        else
-          do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"c3 is closed
-          "%go) in
-          slice.literal #interfaceT ["$sl0"])) in
-          (func_call #fmt.fmt #"Print"%go) "$a0"))
-        )); ("$recvChan3", (λ: "$recvVal",
-        let: "$r0" := (Fst "$recvVal") in
-        do:  ((slice.elem_ref #intT (![#sliceT] "a") ((func_call #unittest.unittest #"f"%go) #())) <-[#intT] "$r0");;;
-        do:  #()
-        ))] (InjR (λ: <>,
+    do:  (chan.select [chan.select_receive (![#(chanT intT)] "c3") (λ: "$recvVal",
+       do:  #()
+       ); chan.select_receive (![#(chanT intT)] "c1") (λ: "$recvVal",
+       let: "$r0" := (Fst "$recvVal") in
+       do:  ("i1" <-[#intT] "$r0");;;
+       do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"received "%go) in
+       let: "$sl1" := (interface.make #""%go #"int"%go (![#intT] "i1")) in
+       let: "$sl2" := (interface.make #""%go #"string"%go #" from c1
+       "%go) in
+       slice.literal #interfaceT ["$sl0"; "$sl1"; "$sl2"])) in
+       (func_call #fmt.fmt #"Print"%go) "$a0")
+       ); chan.select_send (![#intT] "i2") (![#(chanT intT)] "c2") (λ: <>,
+       do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"sent "%go) in
+       let: "$sl1" := (interface.make #""%go #"int"%go (![#intT] "i2")) in
+       let: "$sl2" := (interface.make #""%go #"string"%go #" to c2
+       "%go) in
+       slice.literal #interfaceT ["$sl0"; "$sl1"; "$sl2"])) in
+       (func_call #fmt.fmt #"Print"%go) "$a0")
+       ); chan.select_receive (![#(chanT intT)] "c3") (λ: "$recvVal",
+       let: "ok" := (mem.alloc (type.zero_val #boolT)) in
+       let: "i3" := (mem.alloc (type.zero_val #intT)) in
+       let: ("$ret0", "$ret1") := "$recvVal" in
+       let: "$r0" := "$ret0" in
+       let: "$r1" := "$ret1" in
+       do:  ("i3" <-[#intT] "$r0");;;
+       do:  ("ok" <-[#boolT] "$r1");;;
+       (if: ![#boolT] "ok"
+       then
+         do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"received "%go) in
+         let: "$sl1" := (interface.make #""%go #"int"%go (![#intT] "i3")) in
+         let: "$sl2" := (interface.make #""%go #"string"%go #" from c3
+         "%go) in
+         slice.literal #interfaceT ["$sl0"; "$sl1"; "$sl2"])) in
+         (func_call #fmt.fmt #"Print"%go) "$a0")
+       else
+         do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"c3 is closed
+         "%go) in
+         slice.literal #interfaceT ["$sl0"])) in
+         (func_call #fmt.fmt #"Print"%go) "$a0"))
+       ); chan.select_receive (![#(chanT intT)] "c4") (λ: "$recvVal",
+       let: "$r0" := (Fst "$recvVal") in
+       do:  ((slice.elem_ref #intT (![#sliceT] "a") ((func_call #unittest.unittest #"f"%go) #())) <-[#intT] "$r0");;;
+       do:  #()
+       )] (chan.select_default (λ: <>,
       do:  (let: "$a0" := ((let: "$sl0" := (interface.make #""%go #"string"%go #"no communication
       "%go) in
       slice.literal #interfaceT ["$sl0"])) in
       (func_call #fmt.fmt #"Print"%go) "$a0")
       )));;;
     (for: (λ: <>, #true); (λ: <>, Skip) := λ: <>,
-      do:  (chan.select [("$sendVal0", "$sendChan0", (λ: <>,
-          do:  #()
-          )); ("$sendVal1", "$sendChan1", (λ: <>,
-          do:  #()
-          ))] [] (InjLV #())));;;
-    do:  (chan.select [] [] (InjLV #()))).
+      do:  (chan.select [chan.select_send #(W64 0) (![#(chanT intT)] "c") (λ: <>,
+         do:  #()
+         ); chan.select_send #(W64 1) (![#(chanT intT)] "c") (λ: <>,
+         do:  #()
+         )] chan.select_no_default));;;
+    do:  (chan.select [] chan.select_no_default)).
 
 (* go: chan.go:59:6 *)
 Definition chanDirectional : val :=


### PR DESCRIPTION
The new `chan.select` in Perennial operates on a single list of "select cases", and this updates Goose to emit a translation to work with that model.