### PR TITLE
Fix bug in for range heap allocation for values

### DIFF
--- a/goose.go
+++ b/goose.go
@@ -1798,7 +1798,7 @@ func (ctx *Ctx) rangeStmt(s *ast.RangeStmt) glang.Expr {
 				ctx.nope(s.Value, "expected left side of of `:=` in for range to be an ident")
 			}
 			if value.Name != "_" {
-				t := ctx.glangType(s.Key, ctx.typeOf(s.Key))
+				t := ctx.glangType(s.Value, ctx.typeOf(s.Value))
 				e = glang.LetExpr{
 					Names:   []string{value.Name},
 					ValExpr: glang.RefExpr{X: glang.NewCallExpr(glang.GallinaIdent("type.zero_val"), glang.GolangTypeExpr(t))},

--- a/testdata/examples/append_log/append_log.gold.v
+++ b/testdata/examples/append_log/append_log.gold.v
@@ -131,7 +131,7 @@ Definition writeAll : val :=
     exception_do (let: "off" := (mem.alloc "off") in
     let: "bks" := (mem.alloc "bks") in
     let: "$range" := (![#sliceT] "bks") in
-    (let: "bk" := (mem.alloc (type.zero_val #intT)) in
+    (let: "bk" := (mem.alloc (type.zero_val #sliceT)) in
     let: "i" := (mem.alloc (type.zero_val #intT)) in
     slice.for_range #sliceT "$range" (λ: "$key" "$value",
       do:  ("bk" <-[#sliceT] "$value");;;

--- a/testdata/examples/logging2/logging2.gold.v
+++ b/testdata/examples/logging2/logging2.gold.v
@@ -353,7 +353,7 @@ Definition Txn__Commit : val :=
     let: "$r0" := (mem.alloc (type.zero_val #sliceT)) in
     do:  ("blks" <-[#ptrT] "$r0");;;
     let: "$range" := (![type.mapT #uint64T #sliceT] (struct.field_ref #Txn #"blks"%go "txn")) in
-    (let: "v" := (mem.alloc (type.zero_val #uint64T)) in
+    (let: "v" := (mem.alloc (type.zero_val #sliceT)) in
     map.for_range "$range" (λ: "$key" "value",
       do:  ("v" <-[#sliceT] "$value");;;
       do:  "$key";;;

--- a/testdata/examples/simpledb/simpledb.gold.v
+++ b/testdata/examples/simpledb/simpledb.gold.v
@@ -683,7 +683,7 @@ Definition tablePutBuffer : val :=
     exception_do (let: "buf" := (mem.alloc "buf") in
     let: "w" := (mem.alloc "w") in
     let: "$range" := (![type.mapT #uint64T #sliceT] "buf") in
-    (let: "v" := (mem.alloc (type.zero_val #uint64T)) in
+    (let: "v" := (mem.alloc (type.zero_val #sliceT)) in
     let: "k" := (mem.alloc (type.zero_val #uint64T)) in
     map.for_range "$range" (λ: "$key" "value",
       do:  ("v" <-[#sliceT] "$value");;;

--- a/testdata/examples/unittest/unittest.gold.v
+++ b/testdata/examples/unittest/unittest.gold.v
@@ -1415,7 +1415,7 @@ Definition sumSlice : val :=
     exception_do (let: "xs" := (mem.alloc "xs") in
     let: "sum" := (mem.alloc (type.zero_val #uint64T)) in
     let: "$range" := (![#sliceT] "xs") in
-    (let: "x" := (mem.alloc (type.zero_val #intT)) in
+    (let: "x" := (mem.alloc (type.zero_val #uint64T)) in
     slice.for_range #uint64T "$range" (λ: "$key" "$value",
       do:  ("x" <-[#uint64T] "$value");;;
       do:  "$key";;;


### PR DESCRIPTION
There was a typo (due to copy/pasted code) which incorrectly used the `Key` type for the `Value`.