### PR TITLE
Refactor proofgen type generation a bit

### DIFF
--- a/proofgen/tmpl/tmpl.go
+++ b/proofgen/tmpl/tmpl.go
@@ -46,8 +46,13 @@ func (t TypeAxiom) GoTypeName() string {
 }
 
 type TypeSimple struct {
-	Name string
-	Body string
+	PkgName string
+	Name    string
+	Body    string
+}
+
+func (t TypeSimple) GoTypeName() string {
+	return t.PkgName + "." + t.Name
 }
 
 func (t TypeSimple) Kind() string {

--- a/proofgen/tmpl/tmpl.go
+++ b/proofgen/tmpl/tmpl.go
@@ -28,31 +28,28 @@ type NamesInfo struct {
 	NamedTypeMethods []MethodSet
 }
 
-type TypeDecl interface {
+type TypeDecl struct {
+	PkgName string
+	Name    string
+	TypeInfo
+}
+
+func (t TypeDecl) GoTypeName() string {
+	return t.PkgName + "." + t.Name
+}
+
+type TypeInfo interface {
 	Kind() string
 }
 
-type TypeAxiom struct {
-	PkgName string
-	Name    string
-}
+type TypeAxiom struct{}
 
 func (t TypeAxiom) Kind() string {
 	return "axiom"
 }
 
-func (t TypeAxiom) GoTypeName() string {
-	return t.PkgName + "." + t.Name
-}
-
 type TypeSimple struct {
-	PkgName string
-	Name    string
-	Body    string
-}
-
-func (t TypeSimple) GoTypeName() string {
-	return t.PkgName + "." + t.Name
+	Body string
 }
 
 func (t TypeSimple) Kind() string {
@@ -60,17 +57,11 @@ func (t TypeSimple) Kind() string {
 }
 
 type TypeStruct struct {
-	PkgName string
-	Name    string
-	Fields  []TypeField
+	Fields []TypeField
 }
 
 func (t TypeStruct) Kind() string {
 	return "struct"
-}
-
-func (t TypeStruct) GoTypeName() string {
-	return t.PkgName + "." + t.Name
 }
 
 func (t TypeStruct) FieldsExceptLast() []TypeField {

--- a/proofgen/tmpl/type_simple.tmpl
+++ b/proofgen/tmpl/type_simple.tmpl
@@ -1,6 +1,6 @@
 Module {{.Name}}.
 Section def.
 Context `{ffi_syntax}.
-Definition t := {{.Body}}.
+Definition t := {{.TypeInfo.Body}}.
 End def.
 End {{.Name}}.

--- a/proofgen/tmpl/type_struct.tmpl
+++ b/proofgen/tmpl/type_struct.tmpl
@@ -1,10 +1,11 @@
 {{ $T := . -}}
 {{ $name := $T.Name -}}
+{{ $Fields := $T.TypeInfo.Fields -}}
 Module {{$name}}.
 Section def.
 Context `{ffi_syntax}.
 Record t := mk {
-{{ range .Fields }}  {{.CoqName}} : {{.Type}};
+{{ range $Fields }}  {{.CoqName}} : {{.Type}};
 {{ end -}}
 }.
 End def.
@@ -12,17 +13,17 @@ End {{$name}}.
 
 Section instances.
 Context `{ffi_syntax}.
-{{ if .Fields }}
+{{ if $Fields }}
 Global Instance settable_{{$name}} : Settable _ :=
   settable! {{$name}}.mk < {{- " " -}}
-{{ range .Fields | iterSepFields "; " -}}
+{{ range $Fields | iterSepFields "; " -}}
 {{$name}}.{{ .X.CoqName }}{{.Sep}}
 {{- end }} >.
 {{ end -}}
 Global Instance into_val_{{$name}} : IntoVal {{$name}}.t :=
   {| to_val_def v :=
     struct.val_aux {{$T.GoTypeName}} [
-    {{ range .Fields | iterSepFields ";" -}} {{ $f := .X -}}
+    {{ range $Fields | iterSepFields ";" -}} {{ $f := .X -}}
         "{{$f.Name}}" ::= #({{$name}}.{{$f.CoqName}} v){{.Sep}}
     {{ end -}}
     ]%struct
@@ -30,14 +31,14 @@ Global Instance into_val_{{$name}} : IntoVal {{$name}}.t :=
 
 Global Program Instance into_val_typed_{{$name}} : IntoValTyped {{$name}}.t {{$T.GoTypeName}} :=
 {|
-  default_val := {{$name}}.mk {{- range .Fields }} (default_val _){{ end }};
+  default_val := {{$name}}.mk {{- range $Fields }} (default_val _){{ end }};
 |}.
 Next Obligation. solve_to_val_type. Qed.
 Next Obligation. solve_zero_val. Qed.
 Next Obligation. solve_to_val_inj. Qed.
 Final Obligation. solve_decision. Qed.
 
-{{ range $f := .Fields -}}
+{{ range $f := $Fields -}}
 Global Instance into_val_struct_field_{{$name}}_{{$f.Name}} : {{/* type on next line */ -}}
   IntoValStructField "{{$f.Name}}" {{/* params on next line */ -}}
   {{$T.GoTypeName}} {{$name}}.{{$f.CoqName}}.
@@ -46,21 +47,21 @@ Proof. solve_into_val_struct_field. Qed.
 {{ end }}
 Context `{!ffi_model, !ffi_semantics _ _, !ffi_interp _, !heapGS Σ}.
 Global Instance wp_struct_make_{{$name}}
-{{- range $T.Fields }} {{.CoqName}}{{ end -}} :
+{{- range $Fields }} {{.CoqName}}{{ end -}} :
   PureWp True
     (struct.make #{{$T.GoTypeName}} (alist_val [
-{{ range .Fields | iterSepFields ";" -}}{{ $f := .X -}}
+{{ range $Fields | iterSepFields ";" -}}{{ $f := .X -}}
 {{indent 6}}"{{$f.Name}}" ::= #{{$f.CoqName}}{{.Sep}}
 {{ end -}}
 {{indent 4}}]))%struct
-    #({{$name}}.mk {{- range $T.Fields }} {{.CoqName}}{{ end -}}
+    #({{$name}}.mk {{- range $Fields }} {{.CoqName}}{{ end -}}
 ).
 Proof. solve_struct_make_pure_wp. Qed.
 
-{{ if $T.Fields }}
+{{ if $Fields }}
 Global Instance {{$name}}_struct_fields_split dq l (v : {{$name}}.t) :
   StructFieldsSplit dq l v ( {{- /* continued */}}
-{{ range .Fields | iterSepFields " ∗\n" -}}{{ $f := .X -}}
+{{ range $Fields | iterSepFields " ∗\n" -}}{{ $f := .X -}}
 {{indent 4}}"H{{$f.Name}}" ∷ l ↦s[{{$T.GoTypeName}} :: "{{$f.Name}}"]{dq} v.({{$name}}.{{$f.CoqName}}){{.Sep}}
 {{- end }}
   ).
@@ -70,7 +71,7 @@ Proof.
   unfold_typed_pointsto; split_pointsto_app.
 
   rewrite -!/(typed_pointsto_def _ _ _) -!typed_pointsto_unseal.
-{{ range $f := .FieldsExceptLast -}}
+{{ range $f := .TypeInfo.FieldsExceptLast -}}
   {{indent 2}}simpl_one_flatten_struct (# ({{$name}}.{{$f.CoqName}} v)) {{$T.GoTypeName}} "{{$f.Name}}"%go.
 {{ end }}
   solve_field_ref_f.

--- a/proofgen/tmpl/types.tmpl
+++ b/proofgen/tmpl/types.tmpl
@@ -1,4 +1,5 @@
 {{- range $t := .Types -}}{{ $k := $t.Kind }}
+(* type {{.PkgName}}.{{.Name}} *)
 {{ if eq $k "axiom" -}}
 {{ template "type_axiom.tmpl" $t -}}
 {{ else if eq $k "simple" -}}

--- a/proofgen/types.go
+++ b/proofgen/types.go
@@ -25,6 +25,10 @@ type typesTranslator struct {
 	defNames []string
 }
 
+func (tr typesTranslator) ReadablePos(p token.Pos) string {
+	return tr.pkg.Fset.Position(p).String()
+}
+
 func (tr *typesTranslator) toCoqTypeWithDeps(t types.Type) string {
 	switch t := types.Unalias(t).(type) {
 	case *types.Basic:
@@ -50,7 +54,7 @@ func (tr *typesTranslator) toCoqTypeWithDeps(t types.Type) string {
 			return "unit"
 		} else {
 			panic(fmt.Sprintf("Anonymous structs with fields are not supported (%s): %s",
-				tr.pkg.Fset.Position(t.Field(0).Pos()).String(),
+				tr.ReadablePos(t.Field(0).Pos()),
 				t.String()))
 		}
 	}
@@ -80,8 +84,9 @@ func (tr *typesTranslator) translateSimpleType(spec *ast.TypeSpec, t types.Type)
 	typeBody := tr.toCoqTypeWithDeps(t)
 
 	decl := tmpl.TypeSimple{
-		Name: name,
-		Body: typeBody,
+		PkgName: tr.pkg.Name,
+		Name:    name,
+		Body:    typeBody,
 	}
 	tr.defNames = append(tr.defNames, defName)
 	tr.defs[defName] = decl

--- a/proofgen/types.go
+++ b/proofgen/types.go
@@ -57,66 +57,66 @@ func (tr *typesTranslator) toCoqTypeWithDeps(t types.Type) string {
 				tr.ReadablePos(t.Field(0).Pos()),
 				t.String()))
 		}
+	case *types.TypeParam:
+		return t.Obj().Name()
 	}
 	panic(fmt.Sprintf("Unknown type %v (of type %T)", t, t))
 }
 
-func (tr *typesTranslator) axiomatizeType(spec *ast.TypeSpec) tmpl.TypeAxiom {
+func (tr *typesTranslator) newDecl(spec *ast.TypeSpec, info tmpl.TypeInfo) tmpl.TypeDecl {
+	return tmpl.TypeDecl{
+		PkgName:  tr.pkg.Name,
+		Name:     spec.Name.Name,
+		TypeInfo: info,
+	}
+}
+
+func (tr *typesTranslator) axiomatizeType(spec *ast.TypeSpec) {
 	name := spec.Name.Name
 	defName := name + ".t"
 	tr.deps.SetCurrentName(defName)
 	defer tr.deps.UnsetCurrentName()
-	decl := tmpl.TypeAxiom{
-		PkgName: tr.pkg.Name,
-		Name:    name,
-	}
+
+	decl := tr.newDecl(spec, tmpl.TypeAxiom{})
 	tr.defNames = append(tr.defNames, defName)
 	tr.defs[defName] = decl
-	return decl
 }
 
-func (tr *typesTranslator) translateSimpleType(spec *ast.TypeSpec, t types.Type) tmpl.TypeSimple {
+func (tr *typesTranslator) translateSimpleType(spec *ast.TypeSpec, t types.Type) {
 	name := spec.Name.Name
 	defName := name + ".t"
 	tr.deps.SetCurrentName(defName)
 	defer tr.deps.UnsetCurrentName()
 
 	typeBody := tr.toCoqTypeWithDeps(t)
-
-	decl := tmpl.TypeSimple{
-		PkgName: tr.pkg.Name,
-		Name:    name,
-		Body:    typeBody,
-	}
+	decl := tr.newDecl(spec, tmpl.TypeSimple{
+		Body: typeBody,
+	})
 	tr.defNames = append(tr.defNames, defName)
 	tr.defs[defName] = decl
-	return decl
 }
 
-func (tr *typesTranslator) translateStructType(spec *ast.TypeSpec, s *types.Struct) tmpl.TypeStruct {
+func (tr *typesTranslator) translateStructType(spec *ast.TypeSpec, s *types.Struct) {
 	name := spec.Name.Name
 	defName := name + ".t"
 	tr.deps.SetCurrentName(defName)
 	defer tr.deps.UnsetCurrentName()
 
-	decl := tmpl.TypeStruct{
-		PkgName: tr.pkg.Name,
-		Name:    name,
-	}
+	info := tmpl.TypeStruct{}
 	for i := 0; i < s.NumFields(); i++ {
 		fieldName := s.Field(i).Name()
 		if fieldName == "_" {
 			fieldName = "_" + strconv.Itoa(i)
 		}
 		fieldType := tr.toCoqTypeWithDeps(s.Field(i).Type())
-		decl.Fields = append(decl.Fields, tmpl.TypeField{
+		info.Fields = append(info.Fields, tmpl.TypeField{
 			Name: fieldName,
 			Type: fieldType,
 		})
 	}
+	decl := tr.newDecl(spec, info)
 	tr.defNames = append(tr.defNames, defName)
 	tr.defs[defName] = decl
-	return decl
 }
 
 func (tr *typesTranslator) translateType(spec *ast.TypeSpec) {


### PR DESCRIPTION
Adds a comment before each type block and makes the three kinds of types treated a bit more uniformly.